### PR TITLE
Project serialization

### DIFF
--- a/scripts/build_debug.sh
+++ b/scripts/build_debug.sh
@@ -2,10 +2,5 @@
 
 echo "---------- Building ----------"
 mkdir -p build/ && cd build/
-cmake -DCMAKE_BUILD_TYPE=Debug ..
-# cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++ ..
-
+cmake -DCMAKE_BUILD_TYPE=Debug .. #-DCMAKE_CXX_COMPILER=clang++ ..
 make -j
-
-echo "---------- Executing ----------"
-./bin/atta

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -4,6 +4,3 @@ echo "---------- Building ----------"
 mkdir -p build/ && cd build/
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j
-
-echo "---------- Executing ----------"
-./bin/atta

--- a/src/atta/componentSystem/CMakeLists.txt
+++ b/src/atta/componentSystem/CMakeLists.txt
@@ -28,7 +28,8 @@ set(ATTA_COMPONENT_SYSTEM_SOURCE
 )
 
 add_library(atta_component_system STATIC ${ATTA_COMPONENT_SYSTEM_SOURCE})
-target_link_libraries(atta_component_system PUBLIC ${ATTA_IMGUI_TARGETS})
+target_link_libraries(atta_component_system PUBLIC ${ATTA_IMGUI_TARGETS} 
+    atta_physics_system atta_memory_system atta_sensor_system atta_script_system)
 
 atta_target_common(atta_component_system)
 atta_add_libs(atta_component_system)

--- a/src/atta/core/log.inl
+++ b/src/atta/core/log.inl
@@ -6,6 +6,20 @@
 //--------------------------------------------------
 namespace atta
 {
+    template<typename S, typename T>
+    class is_streamable
+    {
+        template<typename SS, typename TT>
+        static auto test(int)
+        -> decltype( std::declval<SS&>() << std::declval<TT>(), std::true_type() );
+
+        template<typename, typename>
+        static auto test(...) -> std::false_type;
+
+    public:
+        static const bool value = decltype(test<S,T>(0))::value;
+    };
+
     template<class...Args>
     void Log::verbose(std::string tag, std::string text, Args&&... args)
     {
@@ -55,7 +69,11 @@ namespace atta
         s << "{";
         for(typename std::vector<T>::const_iterator ii = v.begin(); ii != v.end(); ++ii)
         {
-            s << *ii;
+            if constexpr(is_streamable<Tstream, T>::value)
+                s << *ii;
+            else
+                s << "?";
+
             if(ii < v.end()-1)
                 s << ", ";
         }
@@ -67,7 +85,12 @@ namespace atta
     std::string getArgStr(T t)
     {
         std::stringstream ss;
-        ss << t;
+
+        if constexpr(is_streamable<std::stringstream, T>::value)
+            ss << t;
+        else
+            ss << typeid(T).name();
+
         return ss.str();
     }
 

--- a/src/atta/core/tests/math.cpp
+++ b/src/atta/core/tests/math.cpp
@@ -6,6 +6,7 @@
 //--------------------------------------------------
 #include <gtest/gtest.h>
 #include <atta/core/math/math.h>
+
 using namespace atta;
 
 namespace

--- a/src/atta/core/tests/stringId.cpp
+++ b/src/atta/core/tests/stringId.cpp
@@ -8,6 +8,7 @@
 #include <atta/core/stringId.h>
 
 using namespace atta;
+
 namespace
 {
     TEST(Core_StringId, ConstexprLiteral)

--- a/src/atta/fileSystem/CMakeLists.txt
+++ b/src/atta/fileSystem/CMakeLists.txt
@@ -11,11 +11,27 @@ set(ATTA_SCRIPT_SYSTEM_SOURCE
     project/projectSerializer.cpp
 
     serializer/serializable.cpp
-    )
+    serializer/section.cpp
+)
 
 add_library(atta_file_system STATIC
     ${ATTA_SCRIPT_SYSTEM_SOURCE}
-    )
+)
+
 target_link_libraries(atta_file_system PRIVATE atta_graphics_system)
 atta_target_common(atta_file_system)
 atta_add_libs(atta_file_system)
+
+########## Testing ##########
+set(ATTA_FILE_SYSTEM_TEST_SOURCES
+    tests/section.cpp
+)
+# Add to global test
+atta_add_tests(${ATTA_FILE_SYSTEM_TEST_SOURCES})
+
+# Create local test
+atta_create_local_test(
+    atta_file_system_test
+    "${ATTA_FILE_SYSTEM_TEST_SOURCES}"
+    "atta_file_system"
+)

--- a/src/atta/fileSystem/CMakeLists.txt
+++ b/src/atta/fileSystem/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(atta_file_system STATIC
     ${ATTA_SCRIPT_SYSTEM_SOURCE}
 )
 
-target_link_libraries(atta_file_system PRIVATE atta_graphics_system)
+target_link_libraries(atta_file_system PUBLIC atta_graphics_system atta_event_system)
 atta_target_common(atta_file_system)
 atta_add_libs(atta_file_system)
 

--- a/src/atta/fileSystem/project/projectSerializer.cpp
+++ b/src/atta/fileSystem/project/projectSerializer.cpp
@@ -38,57 +38,49 @@ namespace atta
 
         // Load data to section 
         Section section;
-        serializeHeader(section);
+        serializeHeader(section["header"]);
+        serializeConfig(section["config"]);
+        serializeComponentSystem(section["componentSystem"]);
+        serializeGraphicsSystem(section["graphicsSystem"]);
+        //LOG_DEBUG("ProjectSerializer", "Saving project: [w]$0", section);
 
-        LOG_DEBUG("ProjectSerializer", "Saving project: [w]$0", section);
-
-        // Write to file
+        // Serialize version
         std::ofstream os(attaTemp, std::ofstream::trunc | std::ofstream::binary);
+        std::string version = "ATTA" + 
+            std::to_string(ATTA_VERSION_MAJOR) + "." + 
+            std::to_string(ATTA_VERSION_MINOR) + "." +
+            std::to_string(ATTA_VERSION_PATCH) + "." +
+            std::to_string(ATTA_VERSION_TWEAK);
+        write(os, version);
+
+        // Serialize data
         section.serialize(os);
         os.close();
 
         // Override atta file with temp file
         fs::rename(attaTemp, _project->getFile());
-
-        //serializeHeader(os);
-        //serializeConfig(os);
-        //serializeComponentSystem(os);
-        //serializeGraphicsSystem(os);
-        //write(os, "end");
     }
 
     void ProjectSerializer::deserialize()
     {
         Section section;
-        //fs::path attaFile = _project->getFile();
+        fs::path attaFile = _project->getFile();
 
-        //std::ifstream is(attaFile, std::ifstream::in | std::ifstream::binary);
+        std::ifstream is(attaFile, std::ifstream::in | std::ifstream::binary);
 
-        //Header header = deserializeHeader(is);
-        ////LOG_VERBOSE("ProjectSerializer", "[*y]Header:[]\n\tversion:$0.$1.$2.$3\n\tproj:$4\n\tcounter:$5", 
-        ////		header.version[0], header.version[1], header.version[2], header.version[3], 
-        ////		header.projectName, header.saveCounter);
+        // Deserialize version
+        std::string version;
+        read(is, version);
+        //LOG_DEBUG("ProjectSerializer", "Version: [w]$0", version);
+        section.deserialize(is);
+        is.close();
 
-        //while(is)
-        //{
-        //    std::string marker;
-        //    read(is, marker);
-        //    if(marker == "config")
-        //        deserializeConfig(is);
-        //    else if(marker == "comp")
-        //        deserializeComponentSystem(is);
-        //    else if(marker == "gfx")
-        //        deserializeGraphicsSystem(is);
-        //    else if(marker == "end")
-        //        break;
-        //    else
-        //    {
-        //        LOG_WARN("ProjectSerializer", "Unknown marker [w]$0[]. The file may be corrupted", marker);
-        //        break;
-        //    }
-        //}
-
-        //is.close();
+        // Deserialize data
+        deserializeHeader(section["header"]);
+        deserializeConfig(section["config"]);
+        deserializeComponentSystem(section["componentSystem"]);
+        deserializeGraphicsSystem(section["graphicsSystem"]);
+        //LOG_DEBUG("ProjectSerializer", "Reading project: [w]$0", section);
     }
 }
 

--- a/src/atta/fileSystem/project/projectSerializer.cpp
+++ b/src/atta/fileSystem/project/projectSerializer.cpp
@@ -6,6 +6,7 @@
 //--------------------------------------------------
 #include <atta/fileSystem/project/projectSerializer.h>
 #include <atta/fileSystem/serializer/serializer.h>
+#include <atta/fileSystem/serializer/section.h>
 #include <atta/cmakeConfig.h>
 
 #include <atta/componentSystem/componentManager.h>
@@ -31,364 +32,57 @@ namespace atta
 
     void ProjectSerializer::serialize()
     {
+        // Serialize to temporary file
         fs::path attaTemp = _project->getFile();
         attaTemp.replace_extension(".atta.temp");
 
-        std::ofstream os(attaTemp, std::ofstream::trunc | std::ofstream::binary);
+        //std::ofstream os(attaTemp, std::ofstream::trunc | std::ofstream::binary);
 
-        serializeHeader(os);
-        serializeConfig(os);
-        serializeComponentSystem(os);
-        serializeGraphicsSystem(os);
-        write(os, "end");
+        //serializeHeader(os);
+        //serializeConfig(os);
+        //serializeComponentSystem(os);
+        //serializeGraphicsSystem(os);
+        //write(os, "end");
 
-        os.close();
+        //os.close();
 
         // Override atta file with temp file
-        fs::rename(attaTemp, _project->getFile());
+        //fs::rename(attaTemp, _project->getFile());
     }
 
     void ProjectSerializer::deserialize()
     {
-        fs::path attaFile = _project->getFile();
+        //fs::path attaFile = _project->getFile();
 
-        std::ifstream is(attaFile, std::ifstream::in | std::ifstream::binary);
+        //std::ifstream is(attaFile, std::ifstream::in | std::ifstream::binary);
 
-        Header header = deserializeHeader(is);
-        //LOG_VERBOSE("ProjectSerializer", "[*y]Header:[]\n\tversion:$0.$1.$2.$3\n\tproj:$4\n\tcounter:$5", 
-        //		header.version[0], header.version[1], header.version[2], header.version[3], 
-        //		header.projectName, header.saveCounter);
+        //Header header = deserializeHeader(is);
+        ////LOG_VERBOSE("ProjectSerializer", "[*y]Header:[]\n\tversion:$0.$1.$2.$3\n\tproj:$4\n\tcounter:$5", 
+        ////		header.version[0], header.version[1], header.version[2], header.version[3], 
+        ////		header.projectName, header.saveCounter);
 
-        while(is)
-        {
-            std::string marker;
-            read(is, marker);
-            if(marker == "config")
-                deserializeConfig(is);
-            else if(marker == "comp")
-                deserializeComponentSystem(is);
-            else if(marker == "gfx")
-                deserializeGraphicsSystem(is);
-            else if(marker == "end")
-                break;
-            else
-            {
-                LOG_WARN("ProjectSerializer", "Unknown marker [w]$0[]. The file may be corrupted", marker);
-                break;
-            }
-        }
+        //while(is)
+        //{
+        //    std::string marker;
+        //    read(is, marker);
+        //    if(marker == "config")
+        //        deserializeConfig(is);
+        //    else if(marker == "comp")
+        //        deserializeComponentSystem(is);
+        //    else if(marker == "gfx")
+        //        deserializeGraphicsSystem(is);
+        //    else if(marker == "end")
+        //        break;
+        //    else
+        //    {
+        //        LOG_WARN("ProjectSerializer", "Unknown marker [w]$0[]. The file may be corrupted", marker);
+        //        break;
+        //    }
+        //}
 
-        is.close();
-    }
-
-    void ProjectSerializer::serializeHeader(std::ofstream& os)
-    {
-        // Atta info
-        write(os, "atta");
-        uint16_t version[] = { ATTA_VERSION_MAJOR, ATTA_VERSION_MINOR, ATTA_VERSION_PATCH, ATTA_VERSION_TWEAK };
-        write(os, version);// Version
-
-        // Project info
-        write(os, "proj");
-        write(os, _project->getName());// Project name
-        uint32_t saveCounter = 0;
-        write(os, saveCounter);// Save counter (number of times that was saved)
-        write(os, "hend");
-    }
-
-    ProjectSerializer::Header ProjectSerializer::deserializeHeader(std::ifstream& is)
-    {
-        std::string marker;
-        Header header;
-
-        while(true)
-        {
-            read(is, marker);
-            if(marker == "hend")
-            {
-                return header;
-            }
-            else if(marker == "atta")
-            {
-                read(is, header.version);
-            }
-            else if(marker == "proj")
-            {
-                read(is, header.projectName);
-                read(is, header.saveCounter);
-            }
-            else
-            {
-                LOG_WARN("ProjectSerializer", "Unknown marker found at the header [w]$0[]", marker);
-                return header;
-            }
-        }
-        return header;
-    }
-
-    void ProjectSerializer::serializeConfig(std::ofstream& os)
-    {
-        write(os, "config");
-
-        // Dt
-        write(os, "dt");
-        write(os, Config::getDt());
-
-        write(os, "cend");
-    }
-
-    void ProjectSerializer::deserializeConfig(std::ifstream& is)
-    {
-        std::string marker;
-        while(true)
-        {
-            read(is, marker);
-            if(marker == "dt")
-            {
-                float dt;
-                read(is, dt);
-                Config::setDt(dt);
-            }
-            else if(marker == "cend")
-            {
-                return;
-            }
-            else
-            {
-                LOG_WARN("ProjectSerializer", "Unknown marker found at the config [w]$0[]", marker);
-            }
-        }
-    }
-
-    void ProjectSerializer::serializeComponentSystem(std::ofstream& os)
-    {
-        std::stringstream oss;
-        std::basic_ostream<char>::pos_type posBefore = oss.tellp();
-
-        //---------- Write to temporary buffer ----------//
-        // Serialize entity ids
-        std::vector<EntityId> entities = ComponentManager::getNoCloneView();
-        write(oss, "id");// Entity id marker
-        write<uint64_t>(oss, entities.size());
-        for(EntityId entity : entities)
-            write(oss, entity);
-
-        // Serialize number of components
-        write<uint32_t>(oss, ComponentManager::getComponentRegistries().size());
-
-        // Serialize components
-        for(auto compReg : ComponentManager::getComponentRegistries())
-        {
-            // Write name
-            write(oss, compReg->getDescription().name);
-
-            // Get all entities that have this component
-            std::vector<std::pair<EntityId,Component*>> pairs;
-            for(auto entity : entities)
-            {
-                Component* comp = ComponentManager::getEntityComponentById(compReg->getId(), entity);
-                if(comp != nullptr)
-                    pairs.push_back(std::make_pair(entity, comp));
-            }
-
-            // Write size in bytes of this next section (can be useful if the component is unknown and can't be deserialized)
-            unsigned totalSectionSize = 0;
-            for(auto compPair : pairs)
-                totalSectionSize += compReg->getSerializedSize(compPair.second) + sizeof(EntityId);
-            write<uint32_t>(oss, totalSectionSize);
-
-            std::basic_ostream<char>::pos_type posBef = oss.tellp();
-            for(auto compPair : pairs)
-            {
-                // TODO Open vector
-                write(oss, compPair.first);
-                compReg->serialize(oss, compPair.second);
-            }
-            ASSERT(oss.tellp()-posBef == totalSectionSize, "Serialized section size and calculated section size does not match");
-        }
-
-        //---------- Flush buffer to file ----------//
-        // Write section header
-        size_t size = (int)oss.tellp() - posBefore;
-        write(os, "comp");// Section title
-        write(os, size);// Section size
-
-        // Write section body
-        char* buffer = new char[size];
-        oss.rdbuf()->pubseekpos(0);// Return to first position
-        oss.rdbuf()->sgetn(buffer, size);// Copy to buffer
-        os.write(reinterpret_cast<const char*>(buffer), size);
-        delete[] buffer;
-    }
-
-    void ProjectSerializer::deserializeComponentSystem(std::ifstream& is)
-    {
-        // Read section size in bytes
-        size_t sizeBytes;
-        read(is, sizeBytes);
-        int endSectionPos = int(is.tellg()) + sizeBytes;// Used to validate position at the end
-
-        // Read section
-        std::string marker;
-        uint32_t numComponents = 0;
-
-        // Read entity ids
-        {
-            read(is, marker);
-            if(marker != "id")
-            {
-                LOG_WARN("ProjectSerializer", "First component marker must be [w]id[], but it is [w]$0[]. Could not load atta file", marker);
-                return;
-            }
-
-            uint64_t numIds;
-            read(is, numIds);
-            for(uint64_t i = 0; i < numIds; i++)
-            {
-                EntityId id;
-                read(is, id);
-
-                EntityId res = ComponentManager::createEntity(id);
-                if(res != id)
-                    LOG_WARN("ProjectSerializer","Could not create entity with id $0", id);
-            }
-        }
-
-        // Read number of components
-        read(is, numComponents);
-
-        for(uint32_t i = 0; i < numComponents; i++)
-        {
-            uint32_t componentSectionSize;// Can be used to skip the component data if it is an unknown component
-
-            // Read component name
-            read(is, marker);
-            read(is, componentSectionSize);
-            ComponentRegistry* compReg = nullptr;
-            int componentSectionEndPos = int(is.tellg()) + componentSectionSize;
-
-            // Find correct component registry
-            for(auto componentRegistry : ComponentManager::getComponentRegistries())
-            {
-                if(componentRegistry->getDescription().name == marker)
-                {
-                    compReg = componentRegistry;
-                    break;
-                }
-            }
-
-            // If not found the component, skip this section
-            if(compReg == nullptr)
-            {
-                is.ignore(componentSectionEndPos);
-                continue;
-            }
-
-            // Deserialize 
-            while(int(is.tellg()) < componentSectionEndPos)
-            {
-                EntityId eid;
-                read(is, eid);
-                Component* component = ComponentManager::addEntityComponentById(compReg->getId(), eid);
-                compReg->deserialize(is, component);
-            }
-
-            // Check finished at right position
-            if(int(is.tellg()) != componentSectionEndPos)
-            {
-                LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for [*w]component $2 section[]. Some data may have been incorrectly initialized for this component", (int)is.tellg(), componentSectionEndPos, compReg->getDescription().name);
-                is.seekg(componentSectionEndPos, std::ios_base::beg);
-            }
-        }
-
-        if(int(is.tellg()) != endSectionPos)
-        {
-            LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for the [*w]component system section[]. Some data may have been incorrectly initialized", (int)is.tellg(), endSectionPos);
-            is.seekg(endSectionPos, std::ios_base::beg);
-        }
-    }
-
-    void ProjectSerializer::serializeGraphicsSystem(std::ofstream& os)
-    {
-        std::stringstream oss;
-        std::basic_ostream<char>::pos_type posBefore = oss.tellp();
-
-        //---------- Write to temporary buffer ----------//
-        // Number of subsections
-        write<uint32_t>(oss, 1);
-        //----- Viewport subsection -----//
-        write(oss, "viewports");
-
-        std::vector<std::shared_ptr<Viewport>> viewports = GraphicsManager::getViewports();
-        unsigned sectionSize = 0;
-        for(auto viewport : viewports)
-            sectionSize += viewport->getSerializedSize();
-        // Serialize section size in bytes
-        write<uint32_t>(oss, sectionSize);
-
-        // Serialize number of viewports
-        write<uint32_t>(oss, viewports.size());
-
-        // Serialize 
-        for(auto viewport : viewports)
-            viewport->serialize(oss);
-
-        //---------- Flush buffer to file ----------//
-        // Write section header
-        size_t size = (int)oss.tellp() - posBefore;
-        write(os, "gfx");// Section title
-        write(os, size);// Section size
-
-        // Write section body
-        char* buffer = new char[size];
-        oss.rdbuf()->pubseekpos(0);// Return to first position
-        oss.rdbuf()->sgetn(buffer, size);// Copy to buffer
-        os.write(reinterpret_cast<const char*>(buffer), size);
-        delete[] buffer;
-    }
-
-    void ProjectSerializer::deserializeGraphicsSystem(std::ifstream& is)
-    {
-        size_t sizeBytes;
-        read(is, sizeBytes);
-        int sectionEndPos = int(is.tellg()) + sizeBytes;// Used to validate position at the end
-
-        unsigned numSections;
-        read(is, numSections);
-
-        unsigned curr = numSections;
-        while(curr--)
-        {
-            std::string marker;
-            read(is, marker);
-
-            if(marker == "viewports")
-            {
-                // Read section size in bytes
-                unsigned sectionSize;
-                read(is, sectionSize);
-
-                // Read number of viewports
-                unsigned numViewports;
-                read(is, numViewports);
-
-                // Deserialize 
-                GraphicsManager::clearViewports();
-                for(unsigned i = 0; i < numViewports; i++)
-                {
-                    std::shared_ptr<Viewport> viewport;
-                    viewport = std::make_shared<Viewport>(Viewport::CreateInfo{});
-                    viewport->deserialize(is);
-                    GraphicsManager::addViewport(viewport);
-                }
-            }
-        }
-
-        if(int(is.tellg()) != sectionEndPos)
-        {
-            LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for the [*w]graphics system section[]. Some data may have been incorrectly initialized", (int)is.tellg(), sectionEndPos);
-            is.seekg(sectionEndPos, std::ios_base::beg);
-        }
+        //is.close();
     }
 }
 
+#include <atta/fileSystem/project/projectSerializerSerialize.cpp>
+#include <atta/fileSystem/project/projectSerializerDeserialize.cpp>

--- a/src/atta/fileSystem/project/projectSerializer.cpp
+++ b/src/atta/fileSystem/project/projectSerializer.cpp
@@ -36,22 +36,30 @@ namespace atta
         fs::path attaTemp = _project->getFile();
         attaTemp.replace_extension(".atta.temp");
 
-        //std::ofstream os(attaTemp, std::ofstream::trunc | std::ofstream::binary);
+        // Load data to section 
+        Section section;
+        serializeHeader(section);
+
+        LOG_DEBUG("ProjectSerializer", "Saving project: [w]$0", section);
+
+        // Write to file
+        std::ofstream os(attaTemp, std::ofstream::trunc | std::ofstream::binary);
+        section.serialize(os);
+        os.close();
+
+        // Override atta file with temp file
+        fs::rename(attaTemp, _project->getFile());
 
         //serializeHeader(os);
         //serializeConfig(os);
         //serializeComponentSystem(os);
         //serializeGraphicsSystem(os);
         //write(os, "end");
-
-        //os.close();
-
-        // Override atta file with temp file
-        //fs::rename(attaTemp, _project->getFile());
     }
 
     void ProjectSerializer::deserialize()
     {
+        Section section;
         //fs::path attaFile = _project->getFile();
 
         //std::ifstream is(attaFile, std::ifstream::in | std::ifstream::binary);

--- a/src/atta/fileSystem/project/projectSerializer.h
+++ b/src/atta/fileSystem/project/projectSerializer.h
@@ -7,6 +7,7 @@
 #ifndef ATTA_FILE_SYSTEM_PROJECT_PROJECT_SERIALIZER_H
 #define ATTA_FILE_SYSTEM_PROJECT_PROJECT_SERIALIZER_H
 #include <atta/fileSystem/project/project.h>
+#include <atta/fileSystem/serializer/section.h>
 
 namespace atta
 {
@@ -20,8 +21,8 @@ namespace atta
         void deserialize();
 
     private:
-        //void serializeHeader(std::ofstream& os);
-        //Header deserializeHeader(std::ifstream& is);
+        void serializeHeader(Section& section);
+        void deserializeHeader(Section& section);
 
         //void serializeConfig(std::ofstream& os);
         //void deserializeConfig(std::ifstream& is);

--- a/src/atta/fileSystem/project/projectSerializer.h
+++ b/src/atta/fileSystem/project/projectSerializer.h
@@ -27,11 +27,11 @@ namespace atta
         void serializeConfig(Section& section);
         void deserializeConfig(Section& section);
 
-        //void serializeComponentSystem(std::ofstream& os);
-        //void deserializeComponentSystem(std::ifstream& is);
+        void serializeComponentSystem(Section& section);
+        void deserializeComponentSystem(Section& section);
 
-        //void serializeGraphicsSystem(std::ofstream& os);
-        //void deserializeGraphicsSystem(std::ifstream& is);
+        void serializeGraphicsSystem(Section& section);
+        void deserializeGraphicsSystem(Section& section);
 
         std::shared_ptr<Project> _project;
     };

--- a/src/atta/fileSystem/project/projectSerializer.h
+++ b/src/atta/fileSystem/project/projectSerializer.h
@@ -20,26 +20,17 @@ namespace atta
         void deserialize();
 
     private:
-        struct Header {
-            // Atta
-            uint16_t version[4];
+        //void serializeHeader(std::ofstream& os);
+        //Header deserializeHeader(std::ifstream& is);
 
-            // Project
-            std::string projectName;	
-            uint32_t saveCounter;	
-        };
+        //void serializeConfig(std::ofstream& os);
+        //void deserializeConfig(std::ifstream& is);
 
-        void serializeHeader(std::ofstream& os);
-        Header deserializeHeader(std::ifstream& is);
+        //void serializeComponentSystem(std::ofstream& os);
+        //void deserializeComponentSystem(std::ifstream& is);
 
-        void serializeConfig(std::ofstream& os);
-        void deserializeConfig(std::ifstream& is);
-
-        void serializeComponentSystem(std::ofstream& os);
-        void deserializeComponentSystem(std::ifstream& is);
-
-        void serializeGraphicsSystem(std::ofstream& os);
-        void deserializeGraphicsSystem(std::ifstream& is);
+        //void serializeGraphicsSystem(std::ofstream& os);
+        //void deserializeGraphicsSystem(std::ifstream& is);
 
         std::shared_ptr<Project> _project;
     };

--- a/src/atta/fileSystem/project/projectSerializer.h
+++ b/src/atta/fileSystem/project/projectSerializer.h
@@ -24,8 +24,8 @@ namespace atta
         void serializeHeader(Section& section);
         void deserializeHeader(Section& section);
 
-        //void serializeConfig(std::ofstream& os);
-        //void deserializeConfig(std::ifstream& is);
+        void serializeConfig(Section& section);
+        void deserializeConfig(Section& section);
 
         //void serializeComponentSystem(std::ofstream& os);
         //void deserializeComponentSystem(std::ifstream& is);

--- a/src/atta/fileSystem/project/projectSerializerDeserialize.cpp
+++ b/src/atta/fileSystem/project/projectSerializerDeserialize.cpp
@@ -1,0 +1,194 @@
+//--------------------------------------------------
+// Atta File System
+// projectSerializerDeserialize.cpp
+// Date: 2022-09-02
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+
+namespace atta
+{
+    //ProjectSerializer::Header ProjectSerializer::deserializeHeader(std::ifstream& is)
+    //{
+    //    //std::string marker;
+    //    //Header header;
+
+    //    //while(true)
+    //    //{
+    //    //    read(is, marker);
+    //    //    if(marker == "hend")
+    //    //    {
+    //    //        return header;
+    //    //    }
+    //    //    else if(marker == "atta")
+    //    //    {
+    //    //        read(is, header.version);
+    //    //    }
+    //    //    else if(marker == "proj")
+    //    //    {
+    //    //        read(is, header.projectName);
+    //    //        read(is, header.saveCounter);
+    //    //    }
+    //    //    else
+    //    //    {
+    //    //        LOG_WARN("ProjectSerializer", "Unknown marker found at the header [w]$0[]", marker);
+    //    //        return header;
+    //    //    }
+    //    //}
+    //    //return header;
+    //}
+
+    //void ProjectSerializer::deserializeConfig(std::ifstream& is)
+    //{
+    //    //std::string marker;
+    //    //while(true)
+    //    //{
+    //    //    read(is, marker);
+    //    //    if(marker == "dt")
+    //    //    {
+    //    //        float dt;
+    //    //        read(is, dt);
+    //    //        Config::setDt(dt);
+    //    //    }
+    //    //    else if(marker == "cend")
+    //    //    {
+    //    //        return;
+    //    //    }
+    //    //    else
+    //    //    {
+    //    //        LOG_WARN("ProjectSerializer", "Unknown marker found at the config [w]$0[]", marker);
+    //    //    }
+    //    //}
+    //}
+
+    //void ProjectSerializer::deserializeComponentSystem(std::ifstream& is)
+    //{
+    //    // Read section size in bytes
+    //    //size_t sizeBytes;
+    //    //read(is, sizeBytes);
+    //    //int endSectionPos = int(is.tellg()) + sizeBytes;// Used to validate position at the end
+
+    //    //// Read section
+    //    //std::string marker;
+    //    //uint32_t numComponents = 0;
+
+    //    //// Read entity ids
+    //    //{
+    //    //    read(is, marker);
+    //    //    if(marker != "id")
+    //    //    {
+    //    //        LOG_WARN("ProjectSerializer", "First component marker must be [w]id[], but it is [w]$0[]. Could not load atta file", marker);
+    //    //        return;
+    //    //    }
+
+    //    //    uint64_t numIds;
+    //    //    read(is, numIds);
+    //    //    for(uint64_t i = 0; i < numIds; i++)
+    //    //    {
+    //    //        EntityId id;
+    //    //        read(is, id);
+
+    //    //        EntityId res = ComponentManager::createEntity(id);
+    //    //        if(res != id)
+    //    //            LOG_WARN("ProjectSerializer","Could not create entity with id $0", id);
+    //    //    }
+    //    //}
+
+    //    //// Read number of components
+    //    //read(is, numComponents);
+
+    //    //for(uint32_t i = 0; i < numComponents; i++)
+    //    //{
+    //    //    uint32_t componentSectionSize;// Can be used to skip the component data if it is an unknown component
+
+    //    //    // Read component name
+    //    //    read(is, marker);
+    //    //    read(is, componentSectionSize);
+    //    //    ComponentRegistry* compReg = nullptr;
+    //    //    int componentSectionEndPos = int(is.tellg()) + componentSectionSize;
+
+    //    //    // Find correct component registry
+    //    //    for(auto componentRegistry : ComponentManager::getComponentRegistries())
+    //    //    {
+    //    //        if(componentRegistry->getDescription().name == marker)
+    //    //        {
+    //    //            compReg = componentRegistry;
+    //    //            break;
+    //    //        }
+    //    //    }
+
+    //    //    // If not found the component, skip this section
+    //    //    if(compReg == nullptr)
+    //    //    {
+    //    //        is.ignore(componentSectionEndPos);
+    //    //        continue;
+    //    //    }
+
+    //    //    // Deserialize 
+    //    //    while(int(is.tellg()) < componentSectionEndPos)
+    //    //    {
+    //    //        EntityId eid;
+    //    //        read(is, eid);
+    //    //        Component* component = ComponentManager::addEntityComponentById(compReg->getId(), eid);
+    //    //        compReg->deserialize(is, component);
+    //    //    }
+
+    //    //    // Check finished at right position
+    //    //    if(int(is.tellg()) != componentSectionEndPos)
+    //    //    {
+    //    //        LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for [*w]component $2 section[]. Some data may have been incorrectly initialized for this component", (int)is.tellg(), componentSectionEndPos, compReg->getDescription().name);
+    //    //        is.seekg(componentSectionEndPos, std::ios_base::beg);
+    //    //    }
+    //    //}
+
+    //    //if(int(is.tellg()) != endSectionPos)
+    //    //{
+    //    //    LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for the [*w]component system section[]. Some data may have been incorrectly initialized", (int)is.tellg(), endSectionPos);
+    //    //    is.seekg(endSectionPos, std::ios_base::beg);
+    //    //}
+    //}
+
+    //void ProjectSerializer::deserializeGraphicsSystem(std::ifstream& is)
+    //{
+    //    //size_t sizeBytes;
+    //    //read(is, sizeBytes);
+    //    //int sectionEndPos = int(is.tellg()) + sizeBytes;// Used to validate position at the end
+
+    //    //unsigned numSections;
+    //    //read(is, numSections);
+
+    //    //unsigned curr = numSections;
+    //    //while(curr--)
+    //    //{
+    //    //    std::string marker;
+    //    //    read(is, marker);
+
+    //    //    if(marker == "viewports")
+    //    //    {
+    //    //        // Read section size in bytes
+    //    //        unsigned sectionSize;
+    //    //        read(is, sectionSize);
+
+    //    //        // Read number of viewports
+    //    //        unsigned numViewports;
+    //    //        read(is, numViewports);
+
+    //    //        // Deserialize 
+    //    //        GraphicsManager::clearViewports();
+    //    //        for(unsigned i = 0; i < numViewports; i++)
+    //    //        {
+    //    //            std::shared_ptr<Viewport> viewport;
+    //    //            viewport = std::make_shared<Viewport>(Viewport::CreateInfo{});
+    //    //            viewport->deserialize(is);
+    //    //            GraphicsManager::addViewport(viewport);
+    //    //        }
+    //    //    }
+    //    //}
+
+    //    //if(int(is.tellg()) != sectionEndPos)
+    //    //{
+    //    //    LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for the [*w]graphics system section[]. Some data may have been incorrectly initialized", (int)is.tellg(), sectionEndPos);
+    //    //    is.seekg(sectionEndPos, std::ios_base::beg);
+    //    //}
+    //}
+}
+

--- a/src/atta/fileSystem/project/projectSerializerDeserialize.cpp
+++ b/src/atta/fileSystem/project/projectSerializerDeserialize.cpp
@@ -37,8 +37,8 @@ namespace atta
     //    //return header;
     }
 
-    //void ProjectSerializer::deserializeConfig(std::ifstream& is)
-    //{
+    void ProjectSerializer::deserializeConfig(Section& is)
+    {
     //    //std::string marker;
     //    //while(true)
     //    //{
@@ -58,7 +58,7 @@ namespace atta
     //    //        LOG_WARN("ProjectSerializer", "Unknown marker found at the config [w]$0[]", marker);
     //    //    }
     //    //}
-    //}
+    }
 
     //void ProjectSerializer::deserializeComponentSystem(std::ifstream& is)
     //{

--- a/src/atta/fileSystem/project/projectSerializerDeserialize.cpp
+++ b/src/atta/fileSystem/project/projectSerializerDeserialize.cpp
@@ -7,8 +7,8 @@
 
 namespace atta
 {
-    //ProjectSerializer::Header ProjectSerializer::deserializeHeader(std::ifstream& is)
-    //{
+    void ProjectSerializer::deserializeHeader(Section& is)
+    {
     //    //std::string marker;
     //    //Header header;
 
@@ -35,7 +35,7 @@ namespace atta
     //    //    }
     //    //}
     //    //return header;
-    //}
+    }
 
     //void ProjectSerializer::deserializeConfig(std::ifstream& is)
     //{

--- a/src/atta/fileSystem/project/projectSerializerDeserialize.cpp
+++ b/src/atta/fileSystem/project/projectSerializerDeserialize.cpp
@@ -7,188 +7,57 @@
 
 namespace atta
 {
-    void ProjectSerializer::deserializeHeader(Section& is)
+    void ProjectSerializer::deserializeHeader(Section& section)
     {
-    //    //std::string marker;
-    //    //Header header;
-
-    //    //while(true)
-    //    //{
-    //    //    read(is, marker);
-    //    //    if(marker == "hend")
-    //    //    {
-    //    //        return header;
-    //    //    }
-    //    //    else if(marker == "atta")
-    //    //    {
-    //    //        read(is, header.version);
-    //    //    }
-    //    //    else if(marker == "proj")
-    //    //    {
-    //    //        read(is, header.projectName);
-    //    //        read(is, header.saveCounter);
-    //    //    }
-    //    //    else
-    //    //    {
-    //    //        LOG_WARN("ProjectSerializer", "Unknown marker found at the header [w]$0[]", marker);
-    //    //        return header;
-    //    //    }
-    //    //}
-    //    //return header;
+        std::vector<uint16_t> version = std::vector<uint16_t>(section["version"]);
+        std::string projectName = std::string(section["projectName"]);
     }
 
-    void ProjectSerializer::deserializeConfig(Section& is)
+    void ProjectSerializer::deserializeConfig(Section& section)
     {
-    //    //std::string marker;
-    //    //while(true)
-    //    //{
-    //    //    read(is, marker);
-    //    //    if(marker == "dt")
-    //    //    {
-    //    //        float dt;
-    //    //        read(is, dt);
-    //    //        Config::setDt(dt);
-    //    //    }
-    //    //    else if(marker == "cend")
-    //    //    {
-    //    //        return;
-    //    //    }
-    //    //    else
-    //    //    {
-    //    //        LOG_WARN("ProjectSerializer", "Unknown marker found at the config [w]$0[]", marker);
-    //    //    }
-    //    //}
+        Config::setDt(float(section["dt"]));
     }
 
-    //void ProjectSerializer::deserializeComponentSystem(std::ifstream& is)
-    //{
-    //    // Read section size in bytes
-    //    //size_t sizeBytes;
-    //    //read(is, sizeBytes);
-    //    //int endSectionPos = int(is.tellg()) + sizeBytes;// Used to validate position at the end
+    void ProjectSerializer::deserializeComponentSystem(Section& section)
+    {
+        // Create entities
+        std::vector<EntityId> entities = std::vector<EntityId>(section["entityIds"]);
+        for(EntityId id : entities)
+        {
+            EntityId res = ComponentManager::createEntity(id);
+            if(res != id)
+                LOG_WARN("ProjectSerializer","Could not create entity with id $0", id);
+        }
 
-    //    //// Read section
-    //    //std::string marker;
-    //    //uint32_t numComponents = 0;
+        // Create and assign components
+        for(auto compReg : ComponentManager::getComponentRegistries())
+        {
+            std::string name = compReg->getDescription().name;
 
-    //    //// Read entity ids
-    //    //{
-    //    //    read(is, marker);
-    //    //    if(marker != "id")
-    //    //    {
-    //    //        LOG_WARN("ProjectSerializer", "First component marker must be [w]id[], but it is [w]$0[]. Could not load atta file", marker);
-    //    //        return;
-    //    //    }
+            // Get all entities that have this component
+            std::vector<EntityId> eids = std::vector<EntityId>(section["components"][name]["entityIds"]);
+            std::vector<uint8_t> componentsData = std::vector<uint8_t>(section["components"][name]["data"]);
+            std::stringstream ss;
+            write(ss, componentsData.data(), componentsData.size());
 
-    //    //    uint64_t numIds;
-    //    //    read(is, numIds);
-    //    //    for(uint64_t i = 0; i < numIds; i++)
-    //    //    {
-    //    //        EntityId id;
-    //    //        read(is, id);
+            for(EntityId eid : eids)
+            {
+                Component* component = ComponentManager::addEntityComponentById(compReg->getId(), eid);
+                compReg->deserialize(ss, component);
+            }
+        }
+    }
 
-    //    //        EntityId res = ComponentManager::createEntity(id);
-    //    //        if(res != id)
-    //    //            LOG_WARN("ProjectSerializer","Could not create entity with id $0", id);
-    //    //    }
-    //    //}
-
-    //    //// Read number of components
-    //    //read(is, numComponents);
-
-    //    //for(uint32_t i = 0; i < numComponents; i++)
-    //    //{
-    //    //    uint32_t componentSectionSize;// Can be used to skip the component data if it is an unknown component
-
-    //    //    // Read component name
-    //    //    read(is, marker);
-    //    //    read(is, componentSectionSize);
-    //    //    ComponentRegistry* compReg = nullptr;
-    //    //    int componentSectionEndPos = int(is.tellg()) + componentSectionSize;
-
-    //    //    // Find correct component registry
-    //    //    for(auto componentRegistry : ComponentManager::getComponentRegistries())
-    //    //    {
-    //    //        if(componentRegistry->getDescription().name == marker)
-    //    //        {
-    //    //            compReg = componentRegistry;
-    //    //            break;
-    //    //        }
-    //    //    }
-
-    //    //    // If not found the component, skip this section
-    //    //    if(compReg == nullptr)
-    //    //    {
-    //    //        is.ignore(componentSectionEndPos);
-    //    //        continue;
-    //    //    }
-
-    //    //    // Deserialize 
-    //    //    while(int(is.tellg()) < componentSectionEndPos)
-    //    //    {
-    //    //        EntityId eid;
-    //    //        read(is, eid);
-    //    //        Component* component = ComponentManager::addEntityComponentById(compReg->getId(), eid);
-    //    //        compReg->deserialize(is, component);
-    //    //    }
-
-    //    //    // Check finished at right position
-    //    //    if(int(is.tellg()) != componentSectionEndPos)
-    //    //    {
-    //    //        LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for [*w]component $2 section[]. Some data may have been incorrectly initialized for this component", (int)is.tellg(), componentSectionEndPos, compReg->getDescription().name);
-    //    //        is.seekg(componentSectionEndPos, std::ios_base::beg);
-    //    //    }
-    //    //}
-
-    //    //if(int(is.tellg()) != endSectionPos)
-    //    //{
-    //    //    LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for the [*w]component system section[]. Some data may have been incorrectly initialized", (int)is.tellg(), endSectionPos);
-    //    //    is.seekg(endSectionPos, std::ios_base::beg);
-    //    //}
-    //}
-
-    //void ProjectSerializer::deserializeGraphicsSystem(std::ifstream& is)
-    //{
-    //    //size_t sizeBytes;
-    //    //read(is, sizeBytes);
-    //    //int sectionEndPos = int(is.tellg()) + sizeBytes;// Used to validate position at the end
-
-    //    //unsigned numSections;
-    //    //read(is, numSections);
-
-    //    //unsigned curr = numSections;
-    //    //while(curr--)
-    //    //{
-    //    //    std::string marker;
-    //    //    read(is, marker);
-
-    //    //    if(marker == "viewports")
-    //    //    {
-    //    //        // Read section size in bytes
-    //    //        unsigned sectionSize;
-    //    //        read(is, sectionSize);
-
-    //    //        // Read number of viewports
-    //    //        unsigned numViewports;
-    //    //        read(is, numViewports);
-
-    //    //        // Deserialize 
-    //    //        GraphicsManager::clearViewports();
-    //    //        for(unsigned i = 0; i < numViewports; i++)
-    //    //        {
-    //    //            std::shared_ptr<Viewport> viewport;
-    //    //            viewport = std::make_shared<Viewport>(Viewport::CreateInfo{});
-    //    //            viewport->deserialize(is);
-    //    //            GraphicsManager::addViewport(viewport);
-    //    //        }
-    //    //    }
-    //    //}
-
-    //    //if(int(is.tellg()) != sectionEndPos)
-    //    //{
-    //    //    LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for the [*w]graphics system section[]. Some data may have been incorrectly initialized", (int)is.tellg(), sectionEndPos);
-    //    //    is.seekg(sectionEndPos, std::ios_base::beg);
-    //    //}
-    //}
+    void ProjectSerializer::deserializeGraphicsSystem(Section& section)
+    {
+        std::vector<Viewport> viewports = std::vector<Viewport>(section["viewports"]);
+        GraphicsManager::clearViewports();
+        for(auto& viewport : viewports)
+        {
+            std::shared_ptr<Viewport> v = std::make_shared<Viewport>();
+            *v = viewport;
+            GraphicsManager::addViewport(v);
+        }
+    }
 }
 

--- a/src/atta/fileSystem/project/projectSerializerSerialize.cpp
+++ b/src/atta/fileSystem/project/projectSerializerSerialize.cpp
@@ -7,20 +7,12 @@
 
 namespace atta
 {
-    //void ProjectSerializer::serializeHeader(std::ofstream& os)
-    //{
-    //    // Atta info
-    //    //write(os, "atta");
-    //    //uint16_t version[] = { ATTA_VERSION_MAJOR, ATTA_VERSION_MINOR, ATTA_VERSION_PATCH, ATTA_VERSION_TWEAK };
-    //    //write(os, version);// Version
-
-    //    //// Project info
-    //    //write(os, "proj");
-    //    //write(os, _project->getName());// Project name
-    //    //uint32_t saveCounter = 0;
-    //    //write(os, saveCounter);// Save counter (number of times that was saved)
-    //    //write(os, "hend");
-    //}
+    void ProjectSerializer::serializeHeader(Section& section)
+    {
+        Section& header = section["header"];
+        header["version"] = std::vector<uint16_t>{ ATTA_VERSION_MAJOR, ATTA_VERSION_MINOR, ATTA_VERSION_PATCH, ATTA_VERSION_TWEAK };
+        header["projectName"] = std::string(_project->getName());
+    }
 
     //void ProjectSerializer::serializeConfig(std::ofstream& os)
     //{

--- a/src/atta/fileSystem/project/projectSerializerSerialize.cpp
+++ b/src/atta/fileSystem/project/projectSerializerSerialize.cpp
@@ -14,16 +14,16 @@ namespace atta
         header["projectName"] = std::string(_project->getName());
     }
 
-    //void ProjectSerializer::serializeConfig(std::ofstream& os)
-    //{
-    //    //write(os, "config");
+    void ProjectSerializer::serializeConfig(Section& section)
+    {
+        //write(os, "config");
 
-    //    //// Dt
-    //    //write(os, "dt");
-    //    //write(os, Config::getDt());
+        //// Dt
+        //write(os, "dt");
+        //write(os, Config::getDt());
 
-    //    //write(os, "cend");
-    //}
+        //write(os, "cend");
+    }
 
     //void ProjectSerializer::serializeComponentSystem(std::ofstream& os)
     //{

--- a/src/atta/fileSystem/project/projectSerializerSerialize.cpp
+++ b/src/atta/fileSystem/project/projectSerializerSerialize.cpp
@@ -1,0 +1,136 @@
+//--------------------------------------------------
+// Atta File System
+// projectSerializerSerialize.cpp
+// Date: 2022-06-02
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+
+namespace atta
+{
+    //void ProjectSerializer::serializeHeader(std::ofstream& os)
+    //{
+    //    // Atta info
+    //    //write(os, "atta");
+    //    //uint16_t version[] = { ATTA_VERSION_MAJOR, ATTA_VERSION_MINOR, ATTA_VERSION_PATCH, ATTA_VERSION_TWEAK };
+    //    //write(os, version);// Version
+
+    //    //// Project info
+    //    //write(os, "proj");
+    //    //write(os, _project->getName());// Project name
+    //    //uint32_t saveCounter = 0;
+    //    //write(os, saveCounter);// Save counter (number of times that was saved)
+    //    //write(os, "hend");
+    //}
+
+    //void ProjectSerializer::serializeConfig(std::ofstream& os)
+    //{
+    //    //write(os, "config");
+
+    //    //// Dt
+    //    //write(os, "dt");
+    //    //write(os, Config::getDt());
+
+    //    //write(os, "cend");
+    //}
+
+    //void ProjectSerializer::serializeComponentSystem(std::ofstream& os)
+    //{
+    //    //std::stringstream oss;
+    //    //std::basic_ostream<char>::pos_type posBefore = oss.tellp();
+
+    //    ////---------- Write to temporary buffer ----------//
+    //    //// Serialize entity ids
+    //    //std::vector<EntityId> entities = ComponentManager::getNoCloneView();
+    //    //write(oss, "id");// Entity id marker
+    //    //write<uint64_t>(oss, entities.size());
+    //    //for(EntityId entity : entities)
+    //    //    write(oss, entity);
+
+    //    //// Serialize number of components
+    //    //write<uint32_t>(oss, ComponentManager::getComponentRegistries().size());
+
+    //    //// Serialize components
+    //    //for(auto compReg : ComponentManager::getComponentRegistries())
+    //    //{
+    //    //    // Write name
+    //    //    write(oss, compReg->getDescription().name);
+
+    //    //    // Get all entities that have this component
+    //    //    std::vector<std::pair<EntityId,Component*>> pairs;
+    //    //    for(auto entity : entities)
+    //    //    {
+    //    //        Component* comp = ComponentManager::getEntityComponentById(compReg->getId(), entity);
+    //    //        if(comp != nullptr)
+    //    //            pairs.push_back(std::make_pair(entity, comp));
+    //    //    }
+
+    //    //    // Write size in bytes of this next section (can be useful if the component is unknown and can't be deserialized)
+    //    //    unsigned totalSectionSize = 0;
+    //    //    for(auto compPair : pairs)
+    //    //        totalSectionSize += compReg->getSerializedSize(compPair.second) + sizeof(EntityId);
+    //    //    write<uint32_t>(oss, totalSectionSize);
+
+    //    //    std::basic_ostream<char>::pos_type posBef = oss.tellp();
+    //    //    for(auto compPair : pairs)
+    //    //    {
+    //    //        // TODO Open vector
+    //    //        write(oss, compPair.first);
+    //    //        compReg->serialize(oss, compPair.second);
+    //    //    }
+    //    //    ASSERT(oss.tellp()-posBef == totalSectionSize, "Serialized section size and calculated section size does not match");
+    //    //}
+
+    //    ////---------- Flush buffer to file ----------//
+    //    //// Write section header
+    //    //size_t size = (int)oss.tellp() - posBefore;
+    //    //write(os, "comp");// Section title
+    //    //write(os, size);// Section size
+
+    //    //// Write section body
+    //    //char* buffer = new char[size];
+    //    //oss.rdbuf()->pubseekpos(0);// Return to first position
+    //    //oss.rdbuf()->sgetn(buffer, size);// Copy to buffer
+    //    //os.write(reinterpret_cast<const char*>(buffer), size);
+    //    //delete[] buffer;
+    //}
+
+    //void ProjectSerializer::serializeGraphicsSystem(std::ofstream& os)
+    //{
+    //    //std::stringstream oss;
+    //    //std::basic_ostream<char>::pos_type posBefore = oss.tellp();
+
+    //    ////---------- Write to temporary buffer ----------//
+    //    //// Number of subsections
+    //    //write<uint32_t>(oss, 1);
+    //    ////----- Viewport subsection -----//
+    //    //write(oss, "viewports");
+
+    //    //std::vector<std::shared_ptr<Viewport>> viewports = GraphicsManager::getViewports();
+    //    //unsigned sectionSize = 0;
+    //    //for(auto viewport : viewports)
+    //    //    sectionSize += viewport->getSerializedSize();
+    //    //// Serialize section size in bytes
+    //    //write<uint32_t>(oss, sectionSize);
+
+    //    //// Serialize number of viewports
+    //    //write<uint32_t>(oss, viewports.size());
+
+    //    //// Serialize 
+    //    //for(auto viewport : viewports)
+    //    //    viewport->serialize(oss);
+
+    //    ////---------- Flush buffer to file ----------//
+    //    //// Write section header
+    //    //size_t size = (int)oss.tellp() - posBefore;
+    //    //write(os, "gfx");// Section title
+    //    //write(os, size);// Section size
+
+    //    //// Write section body
+    //    //char* buffer = new char[size];
+    //    //oss.rdbuf()->pubseekpos(0);// Return to first position
+    //    //oss.rdbuf()->sgetn(buffer, size);// Copy to buffer
+    //    //os.write(reinterpret_cast<const char*>(buffer), size);
+    //    //delete[] buffer;
+    //}
+}
+

--- a/src/atta/fileSystem/serializer/section.cpp
+++ b/src/atta/fileSystem/serializer/section.cpp
@@ -1,0 +1,117 @@
+//--------------------------------------------------
+// Atta File System
+// section.cpp
+// Date: 2022-04-22
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+#include <atta/fileSystem/serializer/section.h>
+
+namespace atta
+{
+    Section::Section()
+    {
+
+    }
+
+    bool Section::isUndefined() const
+    {
+        return !_data.has_value();
+    }
+    
+    bool Section::isMap() const
+    {
+        return _data.type().hash_code() == typeid(std::map<std::string, Section>).hash_code();
+    }
+
+    bool Section::isVector() const
+    {
+        return _data.type().hash_code() == typeid(std::vector<Section>).hash_code();
+    }
+
+    bool Section::isValue() const
+    { 
+        return !(isVector() || isMap());
+    }
+
+    size_t Section::size() const
+    {
+        if(isMap()) return map().size();
+        else if(isVector()) return vector().size();
+        else return 0;
+    }
+
+    std::string Section::toString() const
+    {
+        if(isUndefined()) 
+            return "undefined";
+        else if(isValue())
+            return "value";
+        else if(isMap())
+            return "map";
+        else if(isVector())
+            return "vector";
+        return "";
+    }
+
+    //---------- Value ----------//
+
+    //---------- Map ----------//
+    std::map<std::string, Section>& Section::map()
+    {
+        return *std::any_cast<std::map<std::string, Section>>(&_data);
+    }
+
+    const std::map<std::string, Section>& Section::map() const
+    {
+        return *std::any_cast<std::map<std::string, Section>>(&_data);
+    }
+
+    Section& Section::operator[](std::string key)
+    {
+        if(!isMap())
+            _data = std::map<std::string, Section>{};
+
+        std::map<std::string, Section>* m = std::any_cast<std::map<std::string, Section>>(&_data);
+        return (*m)[key];
+    }
+
+    //---------- Vector ----------//
+    std::vector<Section>& Section::vector()
+    {
+        return *std::any_cast<std::vector<Section>>(&_data);
+    }
+
+    const std::vector<Section>& Section::vector() const
+    {
+        return *std::any_cast<std::vector<Section>>(&_data);
+    }
+
+    Section& Section::operator[](unsigned i)
+    {
+        if(!isVector())
+            _data = std::vector<Section>{};
+
+        std::vector<Section>* v = std::any_cast<std::vector<Section>>(&_data);
+        return (*v)[i];
+    }
+
+    void Section::operator+=(Section section)
+    {
+        vector().push_back(section);
+    }
+
+    void Section::push_back(Section section)
+    {
+        vector().push_back(section);
+    }
+
+    Section& Section::back()
+    {
+        return vector().back();
+    }
+
+    //std::stringstream& operator <<(std::stringstream& ss, const Section& section)
+    //{
+    //    return ss << section.toString();
+    //}
+}

--- a/src/atta/fileSystem/serializer/section.h
+++ b/src/atta/fileSystem/serializer/section.h
@@ -17,6 +17,7 @@ namespace atta
     class SectionData : Serializable
     {
     public:
+        using TypeHash = StringId;
         SectionData();
 
         void clear();
@@ -33,14 +34,13 @@ namespace atta
         template<typename T>
         T* getPtrConst() const;
 
-        size_t getTypeHash() const;
+        TypeHash getTypeHash() const;
 
         std::string toString() const;
         void serialize(std::ostream& os) override;
         void deserialize(std::istream& is) override;
 
     private:
-        using TypeHash = size_t;
         std::vector<uint8_t> _data;
         TypeHash _typeHash;
 

--- a/src/atta/fileSystem/serializer/section.h
+++ b/src/atta/fileSystem/serializer/section.h
@@ -1,0 +1,82 @@
+//--------------------------------------------------
+// Atta File System
+// section.h
+// Date: 2022-04-22
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+#ifndef ATTA_FILE_SYSTEM_SERIALIZER_SECTION_H
+#define ATTA_FILE_SYSTEM_SERIALIZER_SECTION_H
+
+namespace atta
+{
+    /** There are three main possibilities for a section:
+     *  - Map of sections (data as std::map<std::string, Section>)
+     *  - Vector of sections (data as std::vector<Section>)
+     *  - Data 
+     **/
+    class Section
+    {
+    public:
+        Section();
+        template <typename T>
+        Section(T value);
+
+        // Check type
+        bool isUndefined() const;
+        bool isMap() const;
+        bool isVector() const;
+        bool isValue() const;
+
+        size_t size() const;
+        std::string toString() const;
+
+        //----- Value -----//
+        /// Assign value
+        template <typename T>
+        void operator=(T value);
+
+        /// Get value (casting)
+        template <typename T>
+        operator T();
+
+        //----- Map -----//
+        /// Get map
+        std::map<std::string, Section>& map();
+        const std::map<std::string, Section>& map() const;
+
+        /// Map access
+        Section& operator[](std::string key);
+
+        //----- Vector -----//
+        /// Get vector
+        std::vector<Section>& vector();
+        const std::vector<Section>& vector() const;
+
+        /// Vector access
+        Section& operator[](unsigned i);
+        
+        /// Push to vector
+        void push_back(Section section);
+        void operator+=(Section section);
+
+        /// Get last section
+        Section& back();
+
+        /// Assign vector of values
+        template <typename T>
+        void operator=(std::initializer_list<T> list);
+
+    private:
+        std::any _data;
+    };
+
+    // <<
+    inline std::ostream& operator<<(std::ostream& os, const Section& v)
+    {
+        return os << v.toString();
+    }
+}
+#include <atta/fileSystem/serializer/section.inl>
+
+
+#endif// ATTA_FILE_SYSTEM_SERIALIZER_SECTION_H

--- a/src/atta/fileSystem/serializer/section.h
+++ b/src/atta/fileSystem/serializer/section.h
@@ -7,6 +7,7 @@
 #ifndef ATTA_FILE_SYSTEM_SERIALIZER_SECTION_H
 #define ATTA_FILE_SYSTEM_SERIALIZER_SECTION_H
 #include <atta/fileSystem/serializer/serializable.h>
+#include <atta/fileSystem/serializer/serializer.h>
 
 namespace atta
 {
@@ -24,11 +25,13 @@ namespace atta
         void operator=(T&& value);
 
         template<typename T>
-        T get() const;
+        T get();
         template<typename T>
-        const T* getPtr() const;
+        T getConst() const;
         template<typename T>
         T* getPtr();
+        template<typename T>
+        T* getPtrConst() const;
 
         size_t getTypeHash() const;
 

--- a/src/atta/fileSystem/serializer/section.inl
+++ b/src/atta/fileSystem/serializer/section.inl
@@ -7,40 +7,226 @@
 
 namespace atta
 {
+    template<typename Test, template<typename...> class Ref>
+    struct is_specialization : std::false_type {};
+    template<template<typename...> class Ref, typename... Args>
+    struct is_specialization<Ref<Args...>, Ref>: std::true_type {};
+
+    //---------- SectionData ----------//
+    template<typename T>
+    void SectionData::operator=(T&& value)
+    {
+        using U = std::decay_t<T>;
+        //----- Store std::vector -----//
+        if constexpr(is_specialization<U, std::vector>::value)
+        {
+            // If it is std::vector
+            using V = typename U::value_type;
+
+            //LOG_DEBUG("SectionData", "Attrib vector $0", typeid(V).name());
+            _typeHash = typeid(std::vector<V>).hash_code();
+
+            registerType<U>();
+
+            // Allocate space
+            _data.resize(sizeof(V)*value.size());
+
+            // Copy data
+            V* data = (V*)_data.data();
+            for(unsigned i = 0; i < value.size(); i++)
+            {
+                *data = value[i];
+                data++;
+            }
+        }
+        //----- Store std::string -----//
+        else if constexpr(std::is_same_v<U, std::string>)
+        {
+            // If it is std::string
+            _typeHash = typeid(std::string).hash_code();
+            registerType<std::string>();
+
+            _data.resize(value.size());
+            for(unsigned i = 0; i < value.size(); i++)
+                _data[i] = value[i];
+        }
+        //----- Store other types -----//
+        else
+        {
+            // If it is any other type
+            //LOG_DEBUG("SectionData", "Attrib $0", typeid(T).name());
+            _typeHash = typeid(U).hash_code();
+
+            registerType<U>();
+
+            _data.resize(sizeof(U));
+            U* u = (U*)_data.data();
+            *u = value;
+        }
+    }
+
+    template<typename T>
+    T SectionData::get() const
+    {
+        //----- Get std::vector -----//
+        if constexpr(is_specialization<T, std::vector>::value)
+        {
+            using V = typename T::value_type;// Vector value type
+
+            // Build vector from data and return
+            if(_data.size() > 0 && typeid(T).hash_code() == _typeHash)
+            {
+                // Create return vector
+                T vec;
+                vec.resize(_data.size()/sizeof(V));
+
+                // Copy to return vector
+                const V* data = (const V*)&_data.at(0);
+                for(unsigned i = 0; i < vec.size(); i++)
+                    vec[i] = data[i];
+
+                return vec;
+            }
+            else 
+            {
+                LOG_WARN("Filesystem::SectionData", "Wrong section casting to [w]std::vector<$0>[], value is of type [w]$1[]", typeid(V).name(), _typeHash);
+                return T{};
+            }
+        }
+        //----- Get std::string -----//
+        else if constexpr(std::is_same_v<T, std::string>)
+        {
+            std::string str(_data.begin(), _data.end());
+            return str;
+        }
+        //----- Get other types -----//
+        else
+        {
+            // Return data
+            const T* ptr = getPtr<T>();
+            if(ptr == nullptr)
+                return T{};
+            else
+            {
+                T copy = *ptr;
+                return copy;
+            }
+        }
+    }
+
+    template<typename T>
+    const T* SectionData::getPtr() const
+    {
+        if(_data.size() > 0 && typeid(T).hash_code() == _typeHash)
+            return (const T*)&_data.at(0);
+        else
+        {
+            LOG_WARN("Filesystem::SectionData", "Wrong section casting to [w]$0[], value is of type [w]$1[]", typeid(T).name(), _typeHash);
+            return nullptr;
+        }
+    }
+
+    template<typename T>
+    T* SectionData::getPtr()
+    {
+        if(_data.size() > 0 && typeid(T).hash_code() == _typeHash)
+            return (T*)&_data[0];
+        else 
+        {
+            LOG_WARN("Filesystem::SectionData", "Wrong section casting to [w]$0[], value is of type [w]$1[]", typeid(T).name(), _typeHash);
+            return nullptr;
+        }
+    }
+
+    template<typename T>
+    void SectionData::registerType()
+    {
+        if(_typeToString.find(typeid(T).hash_code()) == _typeToString.end())
+        {
+            _typeToString[typeid(T).hash_code()] =
+                [](std::vector<uint8_t> data)
+                {
+                    //----- Print std::vector -----//
+                    if constexpr(is_specialization<T, std::vector>::value)
+                    {
+                        using V = typename T::value_type;// Vector value type
+                        //T vec;
+                        //vec.resize(data.size()/sizeof(V));
+                        //const V* d = (const V*)&data.at(0);
+                        //for(unsigned i = 0; i < vec.size(); i++)
+                        //    vec[i] = d[i];
+
+                        //std::stringstream ss;
+                        //ss << vec;
+                        //return std::string(ss.str());
+                        return "std::vector<" + std::string(typeid(V).name()) + ">";
+                    }
+                    //----- Print std::string -----//
+                    else if constexpr (std::is_same_v<std::string,T> || std::is_same_v<const char*,T>)
+                    {
+                        // If it is string
+                        std::string str(data.begin(), data.end());
+                        return "\"" + str + "\"";
+                    }
+                    //----- Print others -----//
+                    else
+                    {
+                        //if constexpr(is_streamable<std::stringstream, T>::value)
+                        //{
+                        //    // If it is printable
+                        //    std::stringstream ss;
+                        //    ss << *(T*)(&data[0]);
+                        //    return std::string(ss.str());
+                        //}
+                        //else
+                            // Otherwise, print name
+                        return std::string(typeid(T).name());
+                    }
+
+                    return std::string("");
+                };
+        }
+    }
+
+    //---------- Section ----------//
     template <typename T>
     Section::Section(T value)
     {
-        _data = std::any(value);
+        if constexpr(std::is_same_v<T, std::vector<Section>>)
+            vector() = value;
+        else if constexpr(std::is_same_v<T, std::map<std::string, Section>>)
+            map() = value;
+        else
+            data() = value;
     }
-
+    
     template <typename T>
     void Section::operator=(T value)
     {
-        _data = std::any(value);
+        if constexpr(std::is_same_v<T, std::vector<Section>>)
+            vector() = value;
+        else if constexpr(std::is_same_v<T, std::map<std::string, Section>>)
+            map() = value;
+        else
+            data() = value;
     }
 
     template <typename T>
     void Section::operator=(std::initializer_list<T> list)
     {
-        _data = std::vector<T>(list);
+        if constexpr(std::is_same_v<T, Section>)
+            vector() = std::vector<Section>(list);
+        else
+            data() = std::vector<T>(list);
     }
 
     template <typename T>
     Section::operator T()
     {
-        if(isValue())
-        {
-            try
-            {
-                return std::any_cast<T>(_data);
-            }
-            catch(const std::bad_any_cast& e)
-            {
-                LOG_WARN("Filesystem::Section", "Wrong section casting to [w]$0[], value is of type [w]$1[]", typeid(T).name(), _data.type().name());
-            }
-        }
+        if(isData())
+            return _data.get<T>();
         else
-            LOG_WARN("Filesystem::Section", "Trying to cast section as [w]$0[], but this section is not a value", typeid(T).name());
+            LOG_WARN("Filesystem::Section", "Trying to cast section as [w]$0[], but this section is not data", typeid(T).name());
 
         return T{};
     }

--- a/src/atta/fileSystem/serializer/section.inl
+++ b/src/atta/fileSystem/serializer/section.inl
@@ -1,0 +1,47 @@
+//--------------------------------------------------
+// Atta File System
+// section.inl
+// Date: 2022-04-22
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+
+namespace atta
+{
+    template <typename T>
+    Section::Section(T value)
+    {
+        _data = std::any(value);
+    }
+
+    template <typename T>
+    void Section::operator=(T value)
+    {
+        _data = std::any(value);
+    }
+
+    template <typename T>
+    void Section::operator=(std::initializer_list<T> list)
+    {
+        _data = std::vector<T>(list);
+    }
+
+    template <typename T>
+    Section::operator T()
+    {
+        if(isValue())
+        {
+            try
+            {
+                return std::any_cast<T>(_data);
+            }
+            catch(const std::bad_any_cast& e)
+            {
+                LOG_WARN("Filesystem::Section", "Wrong section casting to [w]$0[], value is of type [w]$1[]", typeid(T).name(), _data.type().name());
+            }
+        }
+        else
+            LOG_WARN("Filesystem::Section", "Trying to cast section as [w]$0[], but this section is not a value", typeid(T).name());
+
+        return T{};
+    }
+}

--- a/src/atta/fileSystem/serializer/serializer.h
+++ b/src/atta/fileSystem/serializer/serializer.h
@@ -15,14 +15,16 @@ namespace atta
     inline void write(std::ostream& os, T x);
     template<typename T, size_t N>
     inline void write(std::ostream& os, T(&x)[N]);
-    template <typename It>
-    inline void write(std::ostream& os, It begin, It end);
+    template <typename T>
+    inline void write(std::ostream& os, T* x, size_t size);
 
     // Helpers to read binary data
     template <typename T>
     inline void read(std::istream& is, T& x);
     template<typename T, size_t N>
     inline void read(std::istream& is, T(&x)[N]);
+    template<typename T>
+    inline void read(std::istream& is, T* x, size_t size);
 }
 
 #include <atta/fileSystem/serializer/serializer.inl>

--- a/src/atta/fileSystem/serializer/serializer.inl
+++ b/src/atta/fileSystem/serializer/serializer.inl
@@ -36,11 +36,10 @@ namespace atta
         os.write(reinterpret_cast<const char*>(&x), sizeof(T)*N);
     }
 
-    template <typename It>
-    inline void write(std::ostream& os, It begin, It end)
+    template <typename T>
+    inline void write(std::ostream& os, T* x, size_t size)
     {
-        using Type = std::remove_pointer_t<std::remove_reference_t<It>>;
-        os.write(reinterpret_cast<const char*>(begin), sizeof(Type)*(end-begin));
+        os.write(reinterpret_cast<const char*>(x), size);
     }
 
     //--------------------------//
@@ -82,5 +81,11 @@ namespace atta
     inline void read(std::istream& is, T(&x)[N])
     {
         is.read(reinterpret_cast<char*>(&x), sizeof(T)*N);
+    }
+
+    template<typename T>
+    inline void read(std::istream& is, T* x, size_t size)
+    {
+        is.read(reinterpret_cast<char*>(x), size);
     }
 }

--- a/src/atta/fileSystem/tests/section.cpp
+++ b/src/atta/fileSystem/tests/section.cpp
@@ -1,0 +1,170 @@
+//--------------------------------------------------
+// Atta File System Tests
+// section.cpp
+// Date: 2022-06-02
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <atta/fileSystem/serializer/section.h>
+
+using namespace atta;
+using namespace testing;
+
+namespace
+{
+    TEST(File_Section, Value)
+    {
+        Section section;
+        EXPECT_EQ(section.isUndefined(), true);
+
+        section = int(10);
+        EXPECT_EQ(int(section), 10);
+        EXPECT_EQ(section.isValue(), true);
+        EXPECT_EQ(section.isVector(), false);
+        EXPECT_EQ(section.isMap(), false);
+        EXPECT_EQ(section.isUndefined(), false);
+
+        section = float(20);
+        EXPECT_EQ(float(section), 20.0f);
+
+        section = unsigned(30);
+        EXPECT_EQ(unsigned(section), 30u);
+
+        // Wrong cast, print error and return 0
+        EXPECT_EQ(float(section), 0);
+
+        // Assign vector
+        std::vector<int> vec = {0, 1, 2};
+        EXPECT_EQ(section.isValue(), true);
+        section = vec;
+        ASSERT_THAT(std::vector<int>(section), ElementsAre(0, 1, 2));
+
+        // Assign initializer list
+        section = {1, 2, 3, 4};
+        EXPECT_EQ(section.isValue(), true);
+        ASSERT_THAT(std::vector<int>(section), ElementsAre(1, 2, 3, 4));
+    }
+
+    TEST(File_Section, Map)
+    {
+        Section section;
+
+        // Test section with map of values
+        section["myInt"] = 1;
+        section["myUnsigned"] = 2u;
+        section["myFloat"] = 3.0f;
+        EXPECT_EQ(int(section["myInt"]), 1);
+        EXPECT_EQ(unsigned(section["myUnsigned"]), 2u);
+        EXPECT_EQ(float(section["myFloat"]), 3.0f);
+        EXPECT_EQ(section.isMap(), true);
+
+        // Reset section to be a value
+        section = 1.0f;
+        EXPECT_EQ(float(section), 1.0f);
+        EXPECT_EQ(section.isValue(), true);
+
+        // Nested section as map of values
+        section["child0"]["int"] = 1;
+        section["child0"]["float"] = 1.0f;
+        section["child1"]["unsigned"] = 1u;
+        EXPECT_EQ(section.isMap(), true);
+
+        EXPECT_EQ(int(section["child0"]["int"]), 1);
+        EXPECT_EQ(float(section["child0"]["float"]), 1.0f);
+        EXPECT_EQ(unsigned(section["child1"]["unsigned"]), 1u);
+
+        // Iterate map 
+        std::vector<std::string> keys;
+        for(std::pair<std::string, Section> child : section.map())
+            keys.push_back(child.first);
+        ASSERT_THAT(keys, ElementsAre("child0", "child1"));
+
+        keys.clear();
+        for(const std::pair<const std::string, Section>& child : section.map())
+            keys.push_back(child.first);
+        ASSERT_THAT(keys, ElementsAre("child0", "child1"));
+
+        keys.clear();
+        for(auto [key, value] : section.map())
+            keys.push_back(key);
+        ASSERT_THAT(keys, ElementsAre("child0", "child1"));
+
+        keys.clear();
+        for(const auto& [key, value] : section.map())
+            keys.push_back(key);
+        ASSERT_THAT(keys, ElementsAre("child0", "child1"));
+    }
+
+    TEST(File_Section, Vector)
+    {
+        Section section = std::vector<Section>();
+        EXPECT_EQ(section.isVector(), true);
+        section = std::vector<Section>();
+        EXPECT_EQ(section.isVector(), true);
+
+        // Test section with map of values
+        Section child0;
+        Section child1;
+        child0["test"] = 1;
+        child1["test"] = 2;
+        section = { child0, child1 };
+        EXPECT_EQ(int(section[0]["test"]), 1);
+        EXPECT_EQ(int(section[1]["test"]), 2);
+
+        std::vector<int> values;
+        for(Section s : section.vector())
+            values.push_back(int(s["test"]));
+        ASSERT_THAT(values, ElementsAre(1, 2));
+    }
+
+    TEST(File_Section, Example)
+    {
+        Section section;
+
+        // Header section
+        section["header"]["version"] = std::string("0.0.0");
+        section["header"]["projName"] = std::string("myProject");
+
+        // Component system section
+        struct TestComponent { int test; };
+        Section testComponent;
+        testComponent["entities"] = {1, 2, 3, 4, 5};
+        testComponent["components"] = {TestComponent{1}, TestComponent{2}, TestComponent{3}};
+        section["componentSystem"]["components"]["testComponent0"] = testComponent;
+        section["componentSystem"]["components"]["testComponent1"] = testComponent;
+        EXPECT_EQ(section["componentSystem"].size(), 1);
+        EXPECT_EQ(section["componentSystem"]["components"].size(), 2);
+        EXPECT_EQ(section["componentSystem"]["components"]["testComponent0"].size(), 2);
+        ASSERT_THAT(std::vector<int>(section["componentSystem"]["components"]["testComponent0"]["entities"]), ElementsAre(1, 2, 3, 4, 5));
+        ASSERT_THAT(std::vector<TestComponent>(section["componentSystem"]["components"]["testComponent1"]["components"])[1].test, 2);
+
+        // Resource system section
+        Section material0;
+        material0["name"] = std::string("mat0");
+        material0["albedo"] = vec3(1.0f, 0.0f, 1.0f);
+        material0["roughness"] = 0.5f;
+        material0["metallic"] = 0.0f;
+
+        Section material1 = material0;
+        material1["name"] = std::string("mat1");
+        Section material2 = material0;
+        material2["name"] = std::string("mat2");
+        Section material3 = material0;
+        material3["name"] = std::string("mat3");
+
+        section["resourceSystem"]["materials"] = { material0, material1 };
+        section["resourceSystem"]["materials"].push_back(material2);
+        section["resourceSystem"]["materials"] += material3;
+        EXPECT_EQ(section["resourceSystem"]["materials"].size(), 4);
+        EXPECT_EQ(std::string(section["resourceSystem"]["materials"][0]["name"]), "mat0");
+        EXPECT_EQ(vec3(section["resourceSystem"]["materials"][0]["albedo"]).x, 1.0f);
+        EXPECT_EQ(float(section["resourceSystem"]["materials"][0]["roughness"]), 0.5f);
+        EXPECT_EQ(float(section["resourceSystem"]["materials"][0]["metallic"]), 0.0f);
+        EXPECT_EQ(std::string(section["resourceSystem"]["materials"][1]["name"]), "mat1");
+        EXPECT_EQ(std::string(section["resourceSystem"]["materials"][2]["name"]), "mat2");
+        EXPECT_EQ(std::string(section["resourceSystem"]["materials"][3]["name"]), "mat3");
+
+        LOG_DEBUG("FileSystem::tests::section", "Example: [w]$0[]", section);
+    }
+}

--- a/src/atta/fileSystem/tests/section.cpp
+++ b/src/atta/fileSystem/tests/section.cpp
@@ -221,6 +221,10 @@ namespace
         object.s = "MyObject";
         original["object"] = object;// Serializable object
 
+        object.id = StringId("Objects");
+        object.s = "Objects";
+        original["objects"] = { object, object, object };// Serializable multiple objects
+
         // Check serialized
         EXPECT_EQ(uint8_t(original["one"]), 1);
         EXPECT_EQ(int(original["two"]), 2);
@@ -229,11 +233,12 @@ namespace
         ASSERT_THAT(std::vector<uint16_t>(original["header"]["version"]), ElementsAre(1, 0, 0, 10));
         EXPECT_EQ((std::pair<int, char>(original["components"][0])), std::make_pair(10, 'i'));
         EXPECT_EQ((std::pair<int, char>(original["components"][1])), std::make_pair(20, 'j'));
-        MyObject objectCurr {};
-        objectCurr = MyObject(original["object"]);
-        EXPECT_EQ(objectCurr.f, 1.0f);
-        EXPECT_EQ(objectCurr.id, StringId("MyObject"));
-        EXPECT_EQ(objectCurr.s, "MyObject");
+        EXPECT_EQ(MyObject(original["object"]).f, 1.0f);
+        EXPECT_EQ(MyObject(original["object"]).id, StringId("MyObject"));
+        EXPECT_EQ(MyObject(original["object"]).s, "MyObject");
+        EXPECT_EQ(std::vector<MyObject>(original["objects"]).size(), 3);
+        EXPECT_EQ(std::vector<MyObject>(original["objects"])[0].id, StringId("Objects"));
+        EXPECT_EQ(std::vector<MyObject>(original["objects"])[1].s, "Objects");
 
         // Serialize and deserialize
         std::stringstream ss;
@@ -248,11 +253,12 @@ namespace
         ASSERT_THAT(std::vector<uint16_t>(deserialized["header"]["version"]), ElementsAre(1, 0, 0, 10));
         EXPECT_EQ((std::pair<int, char>(deserialized["components"][0])), std::make_pair(10, 'i'));
         EXPECT_EQ((std::pair<int, char>(deserialized["components"][1])), std::make_pair(20, 'j'));
-        MyObject objectFinal;
-        objectFinal = MyObject(deserialized["object"]);
-        EXPECT_EQ(objectCurr.f, 1.0f);
-        EXPECT_EQ(objectCurr.id, StringId("MyObject"));
-        EXPECT_EQ(objectCurr.s, "MyObject");
+        EXPECT_EQ(MyObject(deserialized["object"]).f, 1.0f);
+        EXPECT_EQ(MyObject(deserialized["object"]).id, StringId("MyObject"));
+        EXPECT_EQ(MyObject(deserialized["object"]).s, "MyObject");
+        EXPECT_EQ(std::vector<MyObject>(deserialized["objects"]).size(), 3);
+        EXPECT_EQ(std::vector<MyObject>(deserialized["objects"])[0].id, StringId("Objects"));
+        EXPECT_EQ(std::vector<MyObject>(deserialized["objects"])[1].s, "Objects");
 
         // Debug print
         //LOG_DEBUG("Tests", "original: \n[w]$0", original);

--- a/src/atta/fileSystem/tests/section.cpp
+++ b/src/atta/fileSystem/tests/section.cpp
@@ -13,14 +13,14 @@ using namespace testing;
 
 namespace
 {
-    TEST(File_Section, Value)
+    TEST(File_Section, Data)
     {
         Section section;
         EXPECT_EQ(section.isUndefined(), true);
 
         section = int(10);
         EXPECT_EQ(int(section), 10);
-        EXPECT_EQ(section.isValue(), true);
+        EXPECT_EQ(section.isData(), true);
         EXPECT_EQ(section.isVector(), false);
         EXPECT_EQ(section.isMap(), false);
         EXPECT_EQ(section.isUndefined(), false);
@@ -36,13 +36,13 @@ namespace
 
         // Assign vector
         std::vector<int> vec = {0, 1, 2};
-        EXPECT_EQ(section.isValue(), true);
+        EXPECT_EQ(section.isData(), true);
         section = vec;
         ASSERT_THAT(std::vector<int>(section), ElementsAre(0, 1, 2));
 
         // Assign initializer list
         section = {1, 2, 3, 4};
-        EXPECT_EQ(section.isValue(), true);
+        EXPECT_EQ(section.isData(), true);
         ASSERT_THAT(std::vector<int>(section), ElementsAre(1, 2, 3, 4));
     }
 
@@ -62,7 +62,7 @@ namespace
         // Reset section to be a value
         section = 1.0f;
         EXPECT_EQ(float(section), 1.0f);
-        EXPECT_EQ(section.isValue(), true);
+        EXPECT_EQ(section.isData(), true);
 
         // Nested section as map of values
         section["child0"]["int"] = 1;
@@ -118,6 +118,8 @@ namespace
         ASSERT_THAT(values, ElementsAre(1, 2));
     }
 
+
+
     TEST(File_Section, Example)
     {
         Section section;
@@ -127,16 +129,21 @@ namespace
         section["header"]["projName"] = std::string("myProject");
 
         // Component system section
-        struct TestComponent { int test; };
+        struct TestComponent
+        {
+            int test;
+        };
+
         Section testComponent;
-        testComponent["entities"] = {1, 2, 3, 4, 5};
-        testComponent["components"] = {TestComponent{1}, TestComponent{2}, TestComponent{3}};
+        testComponent["entities"] = {1, 2, 3};
+        testComponent["components"] = { TestComponent{1}, TestComponent{2}, TestComponent{3} };
         section["componentSystem"]["components"]["testComponent0"] = testComponent;
         section["componentSystem"]["components"]["testComponent1"] = testComponent;
+
         EXPECT_EQ(section["componentSystem"].size(), 1);
         EXPECT_EQ(section["componentSystem"]["components"].size(), 2);
         EXPECT_EQ(section["componentSystem"]["components"]["testComponent0"].size(), 2);
-        ASSERT_THAT(std::vector<int>(section["componentSystem"]["components"]["testComponent0"]["entities"]), ElementsAre(1, 2, 3, 4, 5));
+        ASSERT_THAT(std::vector<int>(section["componentSystem"]["components"]["testComponent0"]["entities"]), ElementsAre(1, 2, 3));
         ASSERT_THAT(std::vector<TestComponent>(section["componentSystem"]["components"]["testComponent1"]["components"])[1].test, 2);
 
         // Resource system section
@@ -156,6 +163,7 @@ namespace
         section["resourceSystem"]["materials"] = { material0, material1 };
         section["resourceSystem"]["materials"].push_back(material2);
         section["resourceSystem"]["materials"] += material3;
+
         EXPECT_EQ(section["resourceSystem"]["materials"].size(), 4);
         EXPECT_EQ(std::string(section["resourceSystem"]["materials"][0]["name"]), "mat0");
         EXPECT_EQ(vec3(section["resourceSystem"]["materials"][0]["albedo"]).x, 1.0f);

--- a/src/atta/graphicsSystem/CMakeLists.txt
+++ b/src/atta/graphicsSystem/CMakeLists.txt
@@ -46,11 +46,13 @@ set(ATTA_GRAPHICS_SYSTEM_SOURCE
 
     layers/layer.cpp
     layers/layerStack.cpp
-    )
+)
 
 add_library(atta_graphics_system STATIC
     ${ATTA_GRAPHICS_SYSTEM_SOURCE}
-    )
-target_link_libraries(atta_graphics_system PUBLIC ${ATTA_GLFW_TARGETS} ${ATTA_GLAD_TARGETS} ${ATTA_IMGUI_TARGETS})
+)
+target_link_libraries(atta_graphics_system PUBLIC ${ATTA_GLFW_TARGETS} ${ATTA_GLAD_TARGETS} ${ATTA_IMGUI_TARGETS} 
+    atta_core atta_component_system atta_file_system atta_resource_system atta_ui_system)
+
 atta_target_common(atta_graphics_system)
 atta_add_libs(atta_graphics_system)

--- a/src/atta/graphicsSystem/viewport.cpp
+++ b/src/atta/graphicsSystem/viewport.cpp
@@ -15,6 +15,12 @@
 
 namespace atta
 {
+    Viewport::Viewport():
+        Viewport(CreateInfo{})
+    {
+
+    }
+
     Viewport::Viewport(CreateInfo info):
         _sid(info.sid), _renderer(info.renderer), _camera(info.camera)
     {

--- a/src/atta/graphicsSystem/viewport.h
+++ b/src/atta/graphicsSystem/viewport.h
@@ -23,6 +23,7 @@ namespace atta
             std::shared_ptr<Camera> camera = nullptr;
             std::string name;
         };
+        Viewport();
         Viewport(CreateInfo info);
         ~Viewport();
 

--- a/src/atta/memorySystem/CMakeLists.txt
+++ b/src/atta/memorySystem/CMakeLists.txt
@@ -22,7 +22,7 @@ set(ATTA_MEMORY_SYSTEM_TEST_SOURCES
     tests/bitmapAllocator.cpp
     tests/allocatedObject.cpp
     tests/speed.cpp
-    )
+)
 # Add to global test
 atta_add_tests(${ATTA_MEMORY_SYSTEM_TEST_SOURCES})
 
@@ -31,4 +31,4 @@ atta_create_local_test(
     atta_memory_system_test
     "${ATTA_MEMORY_SYSTEM_TEST_SOURCES}"
     "atta_memory_system"
-    )
+)

--- a/src/atta/uiSystem/CMakeLists.txt
+++ b/src/atta/uiSystem/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.12)
 set(ATTA_UI_SYSTEM_SOURCE
     uiManager.cpp
 
+    widgets/plot.cpp
+
     layers/uiLayer.cpp
     layers/editor/editorLayer.cpp
     layers/editor/dockSpace.cpp

--- a/src/atta/uiSystem/layers/uiLayer.cpp
+++ b/src/atta/uiSystem/layers/uiLayer.cpp
@@ -30,6 +30,8 @@ namespace atta::ui
         io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
         io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
 
+        // Don't save imgui.ini
+        io.IniFilename = NULL;
 #ifdef ATTA_OS_WEB
         // Disable file-system access when building with Emscripten (no fopen() of the imgui.init file)
         io.IniFilename = NULL;

--- a/src/atta/uiSystem/widgets/plot.cpp
+++ b/src/atta/uiSystem/widgets/plot.cpp
@@ -1,0 +1,33 @@
+//--------------------------------------------------
+// Atta UI System
+// plot.cpp
+// Date: 2022-05-16
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+#include <atta/uiSystem/widgets/plot.h>
+
+namespace atta::ui
+{
+    void plot(InfoOneLine info)
+    {
+        InfoMultiLine infom;
+        if(info.x.size())
+        {
+            infom.x.resize(1);
+            infom.x[0] = info.x;
+        }
+        infom.y.resize(1);
+        infom.y[0] = info.y;
+        infom.color.resize(1);
+        infom.color[0] = info.color;
+        infom.bgColor = info.bgColor;
+        infom.height = info.height;
+        infom.width = info.width;
+        plot(infom);
+    }
+
+    void plot(InfoMultiLine info)
+    {
+
+    }
+}

--- a/src/atta/uiSystem/widgets/plot.h
+++ b/src/atta/uiSystem/widgets/plot.h
@@ -1,0 +1,36 @@
+//--------------------------------------------------
+// Atta UI System
+// plot.h
+// Date: 2022-05-16
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+#ifndef ATTA_UI_SYSTEM_WIDGETS_PLOT_H
+#define ATTA_UI_SYSTEM_WIDGETS_PLOT_H
+
+namespace atta::ui
+{
+    struct InfoOneLine 
+    {
+        std::vector<float> x;
+        std::vector<float> y;
+        vec4 color;
+        vec4 bgColor = vec4(0.3f, 0.3f, 0.3f, 1.0f);
+        float width = -1;
+        float height = -1;
+    };
+
+    struct InfoMultiLine 
+    {
+        std::vector<std::vector<float>> x;
+        std::vector<std::vector<float>> y;
+        std::vector<vec4> color;
+        vec4 bgColor = vec4(0.3f, 0.3f, 0.3f, 1.0f);
+        float width = -1;
+        float height = -1;
+    };
+
+    void plot(InfoOneLine info);
+    void plot(InfoMultiLine info);
+}
+
+#endif// ATTA_UI_SYSTEM_WIDGETS_PLOT_H

--- a/src/extern/solveGoogletest.cmake
+++ b/src/extern/solveGoogletest.cmake
@@ -1,5 +1,5 @@
 if(ATTA_BUILD_TESTS)
-    option(BUILD_GMOCK OFF)
+    option(BUILD_GMOCK ON)
     option(INSTALL_GTEST OFF)
 
     FetchContent_Declare(


### PR DESCRIPTION
## Description
The project serialization was refactored to be less error-prone to serialize data, thus decreasing the chance of generating corrupted files.

Previously, we were relying in `write` and `read` operation to stream buffers, but now there is a `Section` class that takes care of the serialization and deserialization, being only necessary to populate the `Section` object with the data.

## Notes
![notes](https://user-images.githubusercontent.com/17342434/172065068-cb2b33f3-72a7-4568-b3ec-2b27f2910eec.jpg)


## Comparison old and new approaches
While in the old approach it is necessary to handle the streaming of data manually (being necessary to deal with file markers and check for file consistency every time), with the new approach the consistency check and data handling is hidden behind the `Section class`. Below we have the viewport deserialization with the old and new approaches.

Code 1: Old approach to deserialize viewports (not friendly at all)
```c++
size_t sizeBytes;
read(is, sizeBytes);
int sectionEndPos = int(is.tellg()) + sizeBytes;// Used to validate position at the end

unsigned numSections;
read(is, numSections);

unsigned curr = numSections;
while(curr--)
{
    std::string marker;
    read(is, marker);

    if(marker == "viewports")
    {
        // Read section size in bytes
        unsigned sectionSize;
        read(is, sectionSize);

        // Read number of viewports
        unsigned numViewports;
        read(is, numViewports);

        // Deserialize 
        GraphicsManager::clearViewports();
        for(unsigned i = 0; i < numViewports; i++)
        {
            std::shared_ptr<Viewport> viewport;
            viewport = std::make_shared<Viewport>(Viewport::CreateInfo{});
            viewport->deserialize(is);
            GraphicsManager::addViewport(viewport);
        }
    }
}

if(int(is.tellg()) != sectionEndPos)
{
    LOG_WARN("ProjectSerializer", "Expected position ([w]$0[]) and actual position ([w]$1[])does not match for the [*w]graphics system section[]. Some data may have been incorrectly initialized", (int)is.tellg(), sectionEndPos);
    is.seekg(sectionEndPos, std::ios_base::beg);
}
```

Code 2: New approach to deserialize viewports (cute, huggable)
```c++
std::vector<Viewport> viewports = std::vector<Viewport>(section["viewports"]);
GraphicsManager::clearViewports();
for(auto& viewport : viewports)
{
    std::shared_ptr<Viewport> v = std::make_shared<Viewport>();
    *v = viewport;
    GraphicsManager::addViewport(v);
}
```

## `Section` interface
`Section` internal structure works similar to what you expect for `json`, allowing to store:
 - map of `Section`
 - vector of Section
 - binary data
 
The final interface works like:
```c++
Section section;
section["myInt"] = int(2);
section["myMap"]["key1"] = std::string("value1");
section["myMap"]["key2"] = { 1.0f, 2.0f };// 
section["myMap"]["key3"] = { 1, 2, 3, 4 };// Storing std::vector<int>

Section sectionElement;
sectionElement["value"] = float(2);

section["myVector"] = { sectionElement, sectionElement };
section["myVector"] .push_back(sectionElement);
section["myVector"]  += sectionElement;
```

It is possible to loop over maps and vectors as expected:
```c++
for(const auto& [key, val] : section["myMap"].map())
{
    section[key] = std::string("newValue");
}

for(const Section& section : section["myVector"].vector())
{
    section["value"] = float(3);
}
```

To serialize or deserialize is as simple as:
```c++
// (de)serialize to stringstream
Section toSerialize, deserialized;
toSerialize = int(1);

std::stringstream ss;
toSerialize.serialize(ss);
deserialized.deserialize(ss);

// (de)serialize to file
std::ofstream os(fs::path("myfile.bin"));
toSerialize.serialize(os);
os.close();

std::ifstream is(fs::path("myfile.bin"));
deserialized.deserialize(is);
is.close();
```

## `Section` internals
When data is store in a section, the data is copied to a `std::vector<uint8_t>`. When data is retrieved from a section, the data stored in this `std::vector<uint8_t>` is converted back to the type that was requested.

Section work as expected for:
- basic types (class/structs without dynamic allocation, int, float, char, etc)
- std::string
- std::vector of basic types
- serializable classes (classes derived from `atta::Serializable`)
- std::vector of serializable classes

When a class make use of dynamic allocation, `Section` would store a pointer to that allocated memory, not the data itself (for example, a class with std::vector). In this case, for the class to be serializable properly, it should be derived from the `atta::Serializable`, and the `serialize` and `deserialize` methods must be implemented.

Because the only thing that is important is the binary data, it is possible to change the type of data stored in a section dynamically. It is also possible to store large amount of binary data without problems (for example, images or videos).

Check the **notes image** to see how the binary file is organized.