### PR TITLE
Web project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ else()
 endif()
 
 ########## OS Specific ##########
-message(STATUS "System name: ${CMAKE_SYSTEM_NAME}")
+atta_log(Info "Main" "System name: ${CMAKE_SYSTEM_NAME}")
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)#----- Windows build
     set(ATTA_SYSTEM_NAME "Windows")
     list(APPEND ATTA_DEFINITIONS "ATTA_OS_WINDOWS")
@@ -182,6 +182,22 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Emscripten)#----- Web build
     set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} -s ALLOW_MEMORY_GROWTH=1 -s FORCE_FILESYSTEM=1")
     set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} -s NO_DISABLE_EXCEPTION_CATCHING -s EXIT_RUNTIME=1 -s FORCE_FILESYSTEM=1")
     set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} --preload-file ../resources")
+
+
+    if(ATTA_STATIC_PROJECT_FILE)
+        # Copy project file
+        configure_file(${ATTA_STATIC_PROJECT_FILE} project/project.atta COPYONLY)
+
+        get_filename_component(projectDir ${ATTA_STATIC_PROJECT_FILE} DIRECTORY)
+        if(EXISTS "${projectDir}/resources")
+            file(COPY "${projectDir}/resources" DESTINATION "project")
+            set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} --preload-file project/resources")
+        endif()
+
+        set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} --preload-file project/project.atta")
+        message("-------------> ${EMSCRIPTEN_LINK_PROPERTIES}")
+    endif()
+
     if(ATTA_WEB_BUILD_MODULE)
         message(STATUS "Building only javascript module")
         set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} -s WASM=1 -s ENVIRONMENT=web -s MODULARIZE=1 -s EXPORT_NAME=AttaModule -s EXPORT_NAME='createModule' -s SINGLE_FILE=1 -s USE_ES6_IMPORT_META=0 --use-preload-plugins")
@@ -273,20 +289,19 @@ add_executable(atta "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp")
 atta_target_common(atta)
 target_link_libraries(atta PUBLIC ${ATTA_LIBS})
 
-# Web build
-if(ATTA_SYSTEM_NAME MATCHES "Web")
-    set_target_properties(atta PROPERTIES LINK_FLAGS "${ATTA_LINK_PROP}")
-    if(NOT ATTA_WEB_BUILD_MODULE)
-        set_target_properties(atta PROPERTIES SUFFIX ".html")
-    endif()
-endif()
-
 ########## Static project ##########
 if(ATTA_STATIC_PROJECT)
+    # Instead of looking for atta installed in the machine, use the one being built (must for web build)
+    set(CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR};${CMAKE_MODULE_PATH}")
+    file(WRITE ${CMAKE_BINARY_DIR}/Findatta.cmake "include(attaConfig)")
+    set(ATTA_INSTALL_LIBRARIES ${ATTA_LIBS})
+    set(ATTA_INSTALL_INCLUDE_DIRS ${ATTA_INCLUDE_DIRS})
+    set(ATTA_INSTALL_PCH ${ATTA_PCH})
+    configure_file(attaConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/attaConfig.cmake" @ONLY)
+
     get_filename_component(projectDirectory ${ATTA_STATIC_PROJECT_FILE} DIRECTORY)
     add_subdirectory(${projectDirectory} ${projectDirectory}/build)
     # The project targets will are saved to ATTA_PROJECT_TARGETS (atta_add_target macro)
-    #message("------------> ${projectDirectory} targets ${ATTA_PROJECT_TARGETS}")
     target_link_libraries(atta PUBLIC ${ATTA_PROJECT_TARGETS})
 
     # Populate ATTA_STATIC_PROJECT_SCRIPTS to write includes to scripts.h file
@@ -303,81 +318,94 @@ configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/src/atta/scriptSystem/scripts.h"
 )
 
-########## Install files ##########
-# Install atta executable
-install(TARGETS atta 
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    PRIVATE_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/atta-${CMAKE_PROJECT_VERSION}
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/atta-${CMAKE_PROJECT_VERSION}
-)
-# Install atta-X.X.X.X executable
-install(FILES $<TARGET_FILE:atta> TYPE BIN RENAME atta-${CMAKE_PROJECT_VERSION} PERMISSIONS WORLD_EXECUTE)
-
-# Install atta_test-X.X.X.X executable
-if(ATTA_BUILD_TESTS)
-    install(TARGETS atta_test RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-    install(FILES $<TARGET_FILE:atta_test> TYPE BIN RENAME atta_test-${CMAKE_PROJECT_VERSION} PERMISSIONS WORLD_EXECUTE)
+# Web build
+if(ATTA_SYSTEM_NAME MATCHES "Web")
+    set_target_properties(atta PROPERTIES LINK_FLAGS "${ATTA_LINK_PROP}")
+    if(NOT ATTA_WEB_BUILD_MODULE)
+        set_target_properties(atta PROPERTIES SUFFIX ".html")
+    endif()
 endif()
 
-# Install atta includes
-install(DIRECTORY src/atta/ DESTINATION include/atta-${CMAKE_PROJECT_VERSION}/atta
-    FILES_MATCHING REGEX ".*\.(h|inl)$")
+########## Install/Uninstall ##########
+if(NOT (ATTA_SYSTEM_NAME MATCHES "Web"))
+    ########## Install files ##########
+    set(ATTA_VERSION_SAFE atta-${CMAKE_PROJECT_VERSION})
 
-# Install extern includes
-install(DIRECTORY build/_deps/imgui-src/ DESTINATION include/atta-${CMAKE_PROJECT_VERSION}/extern/imgui
-    FILES_MATCHING REGEX ".*\.(h|inl)$")
-install(DIRECTORY src/extern/glad/ DESTINATION include/atta-${CMAKE_PROJECT_VERSION}/extern/glad
-    FILES_MATCHING REGEX ".*\.(h|inl)$")
-install(DIRECTORY src/extern/stb_image/ DESTINATION include/atta-${CMAKE_PROJECT_VERSION}/extern/stb_image
-    FILES_MATCHING REGEX ".*\.(h|inl)$")
+    # Install atta executable
+    install(TARGETS atta 
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        PRIVATE_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${ATTA_VERSION_SAFE}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${ATTA_VERSION_SAFE}
+    )
+    # Install atta-X.X.X.X executable
+    install(FILES $<TARGET_FILE:atta> TYPE BIN RENAME ${ATTA_VERSION_SAFE} PERMISSIONS WORLD_EXECUTE)
 
-# Set install variables
-list(APPEND ATTA_INSTALL_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include/atta-${CMAKE_PROJECT_VERSION})
-list(APPEND ATTA_INSTALL_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include/atta-${CMAKE_PROJECT_VERSION}/extern/imgui)
-list(APPEND ATTA_INSTALL_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include/atta-${CMAKE_PROJECT_VERSION}/extern/glad/include)
-list(APPEND ATTA_INSTALL_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include/atta-${CMAKE_PROJECT_VERSION}/extern/stb_image)
-set(ATTA_INSTALL_PCH ${CMAKE_INSTALL_PREFIX}/include/atta-${CMAKE_PROJECT_VERSION}/atta/pch.h)
-set(ATTA_INSTALL_LIBRARIES ${ATTA_LIBS})
+    # Install atta_test-X.X.X.X executable
+    if(ATTA_BUILD_TESTS)
+        install(TARGETS atta_test RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+        install(FILES $<TARGET_FILE:atta_test> TYPE BIN RENAME atta_test-${CMAKE_PROJECT_VERSION} PERMISSIONS WORLD_EXECUTE)
+    endif()
 
-# Install resources
-install(DIRECTORY resources/ DESTINATION share/atta-${CMAKE_PROJECT_VERSION} PATTERN "resources/*")
+    # Install atta includes
+    install(DIRECTORY src/atta/ DESTINATION include/${ATTA_VERSION_SAFE}/atta
+        FILES_MATCHING REGEX ".*\.(h|inl)$")
 
-# Uninstall target
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/attaUninstall.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/attaUninstall.cmake"
-    @ONLY)
-add_custom_target(uninstall
-    "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/attaUninstall.cmake")
+    # Install extern includes
+    install(DIRECTORY build/_deps/imgui-src/ DESTINATION include/${ATTA_VERSION_SAFE}/extern/imgui
+        FILES_MATCHING REGEX ".*\.(h|inl)$")
+    install(DIRECTORY src/extern/glad/ DESTINATION include/${ATTA_VERSION_SAFE}/extern/glad
+        FILES_MATCHING REGEX ".*\.(h|inl)$")
+    install(DIRECTORY src/extern/stb_image/ DESTINATION include/${ATTA_VERSION_SAFE}/extern/stb_image
+        FILES_MATCHING REGEX ".*\.(h|inl)$")
 
-########## Cmake Package ##########
-include(CMakePackageConfigHelpers)
+    # Set install variables
+    list(APPEND ATTA_INSTALL_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include/${ATTA_VERSION_SAFE})
+    list(APPEND ATTA_INSTALL_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include/${ATTA_VERSION_SAFE}/extern/imgui)
+    list(APPEND ATTA_INSTALL_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include/${ATTA_VERSION_SAFE}/extern/glad/include)
+    list(APPEND ATTA_INSTALL_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include/${ATTA_VERSION_SAFE}/extern/stb_image)
+    set(ATTA_INSTALL_PCH ${CMAKE_INSTALL_PREFIX}/include/${ATTA_VERSION_SAFE}/atta/pch.h)
+    set(ATTA_INSTALL_LIBRARIES ${ATTA_LIBS})
 
-# Create version and config files for find_package
-write_basic_package_version_file(
-	"${CMAKE_CURRENT_BINARY_DIR}/attaConfigVersion.cmake"
-	VERSION ${PROJECT_VERSION}
-	COMPATIBILITY SameMajorVersion
-)
-configure_package_config_file(attaConfig.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/attaConfig.cmake"
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/atta-${CMAKE_PROJECT_VERSION}
-)
-install(
-	FILES
+    # Install resources
+    install(DIRECTORY resources/ DESTINATION share/${ATTA_VERSION_SAFE} PATTERN "resources/*")
+
+    # Uninstall target
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/attaUninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/attaUninstall.cmake"
+        @ONLY)
+    add_custom_target(uninstall
+        "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/attaUninstall.cmake")
+
+    ########## Cmake Package ##########
+    include(CMakePackageConfigHelpers)
+
+    # Create version and config files for find_package
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/attaConfigVersion.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
+    configure_package_config_file(attaConfig.cmake.in
         "${CMAKE_CURRENT_BINARY_DIR}/attaConfig.cmake"
-		"${CMAKE_CURRENT_BINARY_DIR}/attaConfigVersion.cmake"
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/atta-${CMAKE_PROJECT_VERSION}
-)
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ATTA_VERSION_SAFE}
+    )
+    install(
+        FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/attaConfig.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/attaConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ATTA_VERSION_SAFE}
+    )
 
-# Install atta libraries
-install(TARGETS ${ATTA_LIBS}
-	EXPORT atta_targets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/atta-${CMAKE_PROJECT_VERSION}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/atta-${CMAKE_PROJECT_VERSION}
-)
-# Write cmake targets
-install(EXPORT atta_targets
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/atta-${CMAKE_PROJECT_VERSION}
-	FILE attaTargets.cmake
-)
+    # Install atta libraries
+    install(TARGETS ${ATTA_LIBS}
+        EXPORT atta_targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/${ATTA_VERSION_SAFE}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${ATTA_VERSION_SAFE}
+    )
+    # Write cmake targets
+    install(EXPORT atta_targets
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ATTA_VERSION_SAFE}
+        FILE attaTargets.cmake
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,8 @@ if(ATTA_SYSTEM_NAME MATCHES "Web")
 endif()
 
 ########## Install/Uninstall ##########
-if(NOT (ATTA_SYSTEM_NAME MATCHES "Web"))
+# Do not allow to install web build and static build
+if(NOT (ATTA_SYSTEM_NAME MATCHES "Web") AND NOT ATTA_STATIC_PROJECT_FILE)
     ########## Install files ##########
     set(ATTA_VERSION_SAFE atta-${CMAKE_PROJECT_VERSION})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,19 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(atta VERSION 0.0.3.3 LANGUAGES CXX C)
+project(atta VERSION 0.0.3.4 LANGUAGES CXX C)
 
 OPTION(ATTA_BUILD_TESTS
-  "Set to ON to build also the test executables"
-  ON)
+    "Set to ON to build also the test executables"
+    ON)
 OPTION(ATTA_WEB_BUILD_MODULE
-  "Set to ON to generate only the javascript module"
-  OFF)
+    "Set to ON to generate only the javascript module"
+    OFF)
 OPTION(ATTA_BUILD_DOCS
-  "Build the documentation"
-  OFF)
+    "Build the documentation"
+    OFF)
+option(ATTA_STATIC_PROJECT_FILE 
+    "Project to be linked statically to atta" 
+    "")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -18,104 +21,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/atta/cmakeConfig.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/atta/cmakeConfig.h)
 
-
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # Set flags necessary for the script system to work correctly
     set(CMAKE_CXX_FLAGS "-Wl,--export-dynamic")
     set(CMAKE_EXE_LINKER_FLAGS "-Wl,--export-dynamic")
 endif()
-
-########## Build Types ##########
-if(CMAKE_BUILD_TYPE MATCHES Debug)
-    list(APPEND ATTA_DEFINITIONS "ATTA_DEBUG_BUILD")
-endif()
-
-########## OS Specific ##########
-message(STATUS "System name: ${CMAKE_SYSTEM_NAME}")
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)#----- Windows build
-    set(ATTA_SYSTEM_NAME "Windows")
-    list(APPEND ATTA_DEFINITIONS "ATTA_OS_WINDOWS")
-    # Force google test to link the runtimes dynamically (to avoid visual studio link error)
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    # Fix assert __VA_ARGS__ expansion
-    list(APPEND ATTA_OPTIONS /Zc:preprocessor)
-
-elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)#----- MacOS build
-    set(ATTA_SYSTEM_NAME "MacOS")
-    list(APPEND ATTA_DEFINITIONS "ATTA_OS_MACOS")
-
-elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)#----- Linux build
-    set(ATTA_SYSTEM_NAME "Linux")
-    list(APPEND ATTA_DEFINITIONS "ATTA_OS_LINUX")
-
-elseif(CMAKE_SYSTEM_NAME STREQUAL Emscripten)#----- Web build
-    set(ATTA_SYSTEM_NAME "Web")
-    list(APPEND ATTA_DEFINITIONS "ATTA_OS_WEB")
-
-    # Configure web build
-    set(ATTA_BUILD_TESTS OFF CACHE INTERNAL "" FORCE)
-
-    # Configure emscripten link flags
-    set(EMSCRIPTEN_LINK_PROPERTIES "-s USE_WEBGL2=1 -s USE_GLFW=3")
-    set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} -s ALLOW_MEMORY_GROWTH=1 -s FORCE_FILESYSTEM=1")
-    set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} -s NO_DISABLE_EXCEPTION_CATCHING -s EXIT_RUNTIME=1 -s FORCE_FILESYSTEM=1")
-    set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} --preload-file ../resources")
-    if(ATTA_WEB_BUILD_MODULE)
-        message(STATUS "Building only javascript module")
-        set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} -s WASM=1 -s ENVIRONMENT=web -s MODULARIZE=1 -s EXPORT_NAME=AttaModule -s EXPORT_NAME='createModule' -s SINGLE_FILE=1 -s USE_ES6_IMPORT_META=0 --use-preload-plugins")
-    endif()
-    list(APPEND ATTA_LINK_PROP ${EMSCRIPTEN_LINK_PROPERTIES})
-else()#----- Unknown build
-    message(SEND_ERROR "Unknown system name: ${CMAKE_SYSTEM_NAME}")
-endif()
-
-########## Options ##########
-##### Debug #####
-if(CMAKE_BUILD_TYPE MATCHES Debug)
-    if(MSVC)
-        #list(APPEND ATTA_OPTIONS /W4 /WX)
-    else()
-        list(APPEND ATTA_OPTIONS -g -Wall -Wextra -Wpedantic)
-        # Profilling
-        list(APPEND ATTA_OPTIONS -fno-omit-frame-pointer)
-        # Unused parameter
-        list(APPEND ATTA_OPTIONS -Wno-unused-parameter)
-        # Math anonymous union 
-        #list(APPEND ATTA_OPTIONS -Wno-nested-anon-types -Wno-gnu-anonymous-struct)
-        # Glad opengl definitions
-        #list(APPEND ATTA_OPTIONS -Wno-macro-redefined)
-        # Scripting
-        #list(APPEND ATTA_OPTIONS -Wl,--no-undefined -rdynamic)
-        #list(APPEND ATTA_OPTIONS -Wl,--export-dynamic)
-    endif()
-endif()
-
-##### Releaese #####
-if(CMAKE_BUILD_TYPE MATCHES Release)
-    if(MSVC)
-        list(APPEND ATTA_OPTIONS /O2)
-    else()
-        list(APPEND ATTA_OPTIONS -O3)
-    endif()
-endif()
-
-##### Default #####
-if(MSVC)
-else()
-    # ImGui warnings
-    list(APPEND ATTA_OPTIONS -Wno-invalid-noreturn -Wno-format-security)
-    # Useful to ignore
-    list(APPEND ATTA_OPTIONS -Wno-missing-field-initializers -Wno-invalid-offsetof -Wno-char-subscripts)
-endif()
-
-########## Output Directories ##########
-set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin CACHE INTERNAL "" FORCE)
-set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib CACHE INTERNAL "" FORCE)
-set(ATTA_TEST_PATH ${CMAKE_BINARY_DIR}/bin/tests CACHE INTERNAL "" FORCE)
-set(ATTA_PATH ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "" FORCE)
-
-########## Precompiled Headers ##########
-list(APPEND ATTA_PCH "${CMAKE_CURRENT_SOURCE_DIR}/src/atta/pch.h")
 
 ########## Macros ##########
 macro(atta_add_libs)
@@ -229,12 +139,112 @@ macro(atta_log type tag message)
     message(STATUS "${Bold}${atta_log_color}[${tag}] ${Reset}${atta_log_color}${message}${Reset}")
 endmacro()
 
+########## Build Types ##########
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    list(APPEND ATTA_DEFINITIONS "ATTA_DEBUG_BUILD")
+endif()
+
+if(ATTA_STATIC_PROJECT_FILE)
+    set(ATTA_STATIC_PROJECT TRUE)
+    list(APPEND ATTA_DEFINITIONS "ATTA_STATIC_PROJECT")
+    atta_log(Info "Main" "Building atta statically linked to ${ATTA_STATIC_PROJECT_FILE}")
+else()
+    set(ATTA_STATIC_PROJECT FALSE)
+endif()
+
+########## OS Specific ##########
+message(STATUS "System name: ${CMAKE_SYSTEM_NAME}")
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)#----- Windows build
+    set(ATTA_SYSTEM_NAME "Windows")
+    list(APPEND ATTA_DEFINITIONS "ATTA_OS_WINDOWS")
+    # Force google test to link the runtimes dynamically (to avoid visual studio link error)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    # Fix assert __VA_ARGS__ expansion
+    list(APPEND ATTA_OPTIONS /Zc:preprocessor)
+
+elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)#----- MacOS build
+    set(ATTA_SYSTEM_NAME "MacOS")
+    list(APPEND ATTA_DEFINITIONS "ATTA_OS_MACOS")
+
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)#----- Linux build
+    set(ATTA_SYSTEM_NAME "Linux")
+    list(APPEND ATTA_DEFINITIONS "ATTA_OS_LINUX")
+
+elseif(CMAKE_SYSTEM_NAME STREQUAL Emscripten)#----- Web build
+    set(ATTA_SYSTEM_NAME "Web")
+    list(APPEND ATTA_DEFINITIONS "ATTA_OS_WEB")
+
+    # Configure web build
+    set(ATTA_BUILD_TESTS OFF CACHE INTERNAL "" FORCE)
+
+    # Configure emscripten link flags
+    set(EMSCRIPTEN_LINK_PROPERTIES "-s USE_WEBGL2=1 -s USE_GLFW=3")
+    set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} -s ALLOW_MEMORY_GROWTH=1 -s FORCE_FILESYSTEM=1")
+    set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} -s NO_DISABLE_EXCEPTION_CATCHING -s EXIT_RUNTIME=1 -s FORCE_FILESYSTEM=1")
+    set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} --preload-file ../resources")
+    if(ATTA_WEB_BUILD_MODULE)
+        message(STATUS "Building only javascript module")
+        set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} -s WASM=1 -s ENVIRONMENT=web -s MODULARIZE=1 -s EXPORT_NAME=AttaModule -s EXPORT_NAME='createModule' -s SINGLE_FILE=1 -s USE_ES6_IMPORT_META=0 --use-preload-plugins")
+    endif()
+    list(APPEND ATTA_LINK_PROP ${EMSCRIPTEN_LINK_PROPERTIES})
+else()#----- Unknown build
+    message(SEND_ERROR "Unknown system name: ${CMAKE_SYSTEM_NAME}")
+endif()
+
+########## Options ##########
+##### Debug #####
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    if(MSVC)
+        #list(APPEND ATTA_OPTIONS /W4 /WX)
+    else()
+        list(APPEND ATTA_OPTIONS -g -Wall -Wextra -Wpedantic)
+        # Profilling
+        list(APPEND ATTA_OPTIONS -fno-omit-frame-pointer)
+        # Unused parameter
+        list(APPEND ATTA_OPTIONS -Wno-unused-parameter)
+        # Math anonymous union 
+        #list(APPEND ATTA_OPTIONS -Wno-nested-anon-types -Wno-gnu-anonymous-struct)
+        # Glad opengl definitions
+        #list(APPEND ATTA_OPTIONS -Wno-macro-redefined)
+        # Scripting
+        #list(APPEND ATTA_OPTIONS -Wl,--no-undefined -rdynamic)
+        #list(APPEND ATTA_OPTIONS -Wl,--export-dynamic)
+    endif()
+endif()
+
+##### Releaese #####
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    if(MSVC)
+        list(APPEND ATTA_OPTIONS /O2)
+    else()
+        list(APPEND ATTA_OPTIONS -O3)
+    endif()
+endif()
+
+##### Default #####
+if(MSVC)
+else()
+    # ImGui warnings
+    list(APPEND ATTA_OPTIONS -Wno-invalid-noreturn -Wno-format-security)
+    # Useful to ignore
+    list(APPEND ATTA_OPTIONS -Wno-missing-field-initializers -Wno-invalid-offsetof -Wno-char-subscripts)
+endif()
+
+########## Output Directories ##########
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin CACHE INTERNAL "" FORCE)
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib CACHE INTERNAL "" FORCE)
+set(ATTA_TEST_PATH ${CMAKE_BINARY_DIR}/bin/tests CACHE INTERNAL "" FORCE)
+set(ATTA_PATH ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "" FORCE)
+
+########## Precompiled Headers ##########
+list(APPEND ATTA_PCH "${CMAKE_CURRENT_SOURCE_DIR}/src/atta/pch.h")
+
+
 ########## Atta/Extern directories ##########
 include(FetchContent)
 list(APPEND ATTA_INCLUDE_DIRS ${ATTA_PATH}/src)
 include(${CMAKE_CURRENT_SOURCE_DIR}/src/extern/extern.cmake)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/atta)
-
 
 ########## Docs ##########
 if(ATTA_BUILD_DOCS)
@@ -270,6 +280,28 @@ if(ATTA_SYSTEM_NAME MATCHES "Web")
         set_target_properties(atta PROPERTIES SUFFIX ".html")
     endif()
 endif()
+
+########## Static project ##########
+if(ATTA_STATIC_PROJECT)
+    get_filename_component(projectDirectory ${ATTA_STATIC_PROJECT_FILE} DIRECTORY)
+    add_subdirectory(${projectDirectory} ${projectDirectory}/build)
+    # The project targets will are saved to ATTA_PROJECT_TARGETS (atta_add_target macro)
+    #message("------------> ${projectDirectory} targets ${ATTA_PROJECT_TARGETS}")
+    target_link_libraries(atta PUBLIC ${ATTA_PROJECT_TARGETS})
+
+    # Populate ATTA_STATIC_PROJECT_SCRIPTS to write includes to scripts.h file
+    set(ATTA_STATIC_PROJECT_SCRIPTS "")
+    foreach(projHeader IN LISTS ATTA_PROJECT_HEADERS)
+        if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${possible}")
+            set(ATTA_STATIC_PROJECT_SCRIPTS "${ATTA_STATIC_PROJECT_SCRIPTS}#include \"${projHeader}\"\n")
+        endif()
+    endforeach()
+endif()
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/atta/scriptSystem/scripts.h.in" 
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/atta/scriptSystem/scripts.h"
+)
 
 ########## Install files ##########
 # Install atta executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Emscripten)#----- Web build
         endif()
 
         set(EMSCRIPTEN_LINK_PROPERTIES "${EMSCRIPTEN_LINK_PROPERTIES} --preload-file project/project.atta")
-        message("-------------> ${EMSCRIPTEN_LINK_PROPERTIES}")
     endif()
 
     if(ATTA_WEB_BUILD_MODULE)

--- a/attaConfig.cmake.in
+++ b/attaConfig.cmake.in
@@ -10,9 +10,36 @@ set(atta_PCH "@ATTA_INSTALL_PCH@")
 set(atta_FOUND TRUE)
 
 macro(atta_add_target target sources)
-    add_library(${target} SHARED
-        ${sources}
-    )
+    if(ATTA_STATIC_PROJECT)
+        add_library(${target} STATIC ${sources})
+    else()
+        add_library(${target} SHARED ${sources})
+    endif()
+
     target_include_directories(${target} PRIVATE ${atta_INCLUDE_DIRS})
     target_precompile_headers(${target} PRIVATE ${atta_PCH})
+
+    # This variable is used to include headers when building statically (necessary to register scripts)
+    set(headers "")
+    string(REGEX REPLACE "[.]cpp$" ".h" possibleh ${sources})
+    string(REGEX REPLACE "[.]cpp$" ".hpp" possiblehpp ${sources})
+    set(possibles ${possibleh};${possiblehpp})
+    foreach(possible IN LISTS possibles)
+        if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${possible}")
+            list(APPEND headers "${CMAKE_CURRENT_LIST_DIR}/${possible}")
+        endif()
+    endforeach()
+    list(APPEND ATTA_PROJECT_HEADERS ${headers})
+
+    # This variable is used to know which targets shuld be linked to atta when building statically
+    list(APPEND ATTA_PROJECT_TARGETS ${target})
+    # Update variable
+    get_directory_property(hasParent PARENT_DIRECTORY)
+    if(hasParent)
+        set(ATTA_PROJECT_TARGETS ${ATTA_PROJECT_TARGETS} PARENT_SCOPE)
+        set(ATTA_PROJECT_HEADERS ${ATTA_PROJECT_HEADERS} PARENT_SCOPE)
+    else()
+        set(ATTA_PROJECT_TARGETS ${ATTA_PROJECT_TARGETS})
+        set(ATTA_PROJECT_HEADERS ${ATTA_PROJECT_HEADERS})
+    endif()
 endmacro()

--- a/attaConfig.cmake.in
+++ b/attaConfig.cmake.in
@@ -1,4 +1,6 @@
-include("${CMAKE_CURRENT_LIST_DIR}/attaTargets.cmake")
+if(NOT ATTA_STATIC_PROJECT)
+    include("${CMAKE_CURRENT_LIST_DIR}/attaTargets.cmake")
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/atta/atta.cpp
+++ b/src/atta/atta.cpp
@@ -44,8 +44,8 @@ namespace atta
         Config::init();
         FileManager::startUp();
 
-        uint64_t size = 1.5 * 1024UL * 1024UL * 1024UL;
-        _mainAllocator = new StackAllocator(size);// Allocate 1.5GB for the whole system
+        uint64_t size = 1.0 * 1024UL * 1024UL * 1024UL;
+        _mainAllocator = new StackAllocator(size);// Allocate 1.0GB for the whole system
         MemoryManager::registerAllocator(SSID("MainAllocator"), 
                 static_cast<Allocator*>(_mainAllocator));
 

--- a/src/atta/atta.cpp
+++ b/src/atta/atta.cpp
@@ -24,6 +24,7 @@
 #include <atta/sensorSystem/sensorManager.h>
 #include <atta/uiSystem/uiManager.h>
 #include <atta/core/config.h>
+#include <atta/cmakeConfig.h>
 
 #include <atta/ioSystem/http/http.h>
 
@@ -64,8 +65,18 @@ namespace atta
         EventManager::subscribe<SimulationStopEvent>(BIND_EVENT_FUNC(Atta::onSimulationStateChange));
 
         LOG_SUCCESS("Atta", "Initialized");
+#ifdef ATTA_STATIC_PROJECT
+        fs::path projectFile = fs::path(ATTA_STATIC_PROJECT_FILE);
+        // If project is built statically, open project
+        FileManager::openProject(projectFile);
+
+        if(!info.projectFile.empty() && info.projectFile != projectFile)
+            LOG_WARN("Atta", "Project [w]$0[] will not be open because atta was built statically linked to [w]$1[]", info.projectFile, projectFile);
+#else
+        // If a project was defined as argument, open project
         if(!info.projectFile.empty())
             FileManager::openProject(info.projectFile);
+#endif
     }
 
     Atta::~Atta()

--- a/src/atta/cmakeConfig.h.in
+++ b/src/atta/cmakeConfig.h.in
@@ -22,4 +22,15 @@
 // Directory to look which atta versions are installed
 #define ATTA_INSTALLED_VERSIONS_DIR "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@"
 
+// Project path when atta is built statically linked to one project
+#ifdef ATTA_STATIC_PROJECT 
+
+#ifdef ATTA_OS_WEB
+#define ATTA_STATIC_PROJECT_FILE "/project.atta"
+#else
+#define ATTA_STATIC_PROJECT_FILE "@ATTA_STATIC_PROJECT_FILE@"
+#endif
+
+#endif
+
 #endif// ATTA_CMAKE_CONFIG

--- a/src/atta/cmakeConfig.h.in
+++ b/src/atta/cmakeConfig.h.in
@@ -26,7 +26,7 @@
 #ifdef ATTA_STATIC_PROJECT 
 
 #ifdef ATTA_OS_WEB
-#define ATTA_STATIC_PROJECT_FILE "/project.atta"
+#define ATTA_STATIC_PROJECT_FILE "/project/project.atta"
 #else
 #define ATTA_STATIC_PROJECT_FILE "@ATTA_STATIC_PROJECT_FILE@"
 #endif

--- a/src/atta/componentSystem/componentManager.cpp
+++ b/src/atta/componentSystem/componentManager.cpp
@@ -27,7 +27,7 @@ namespace atta
         //----- System Memory -----//
         // Get main memory
         Allocator* mainAllocator = MemoryManager::getAllocator(SSID("MainAllocator"));
-        size_t size = 512*1024*1024;// 512MB
+        size_t size = 128*1024*1024;// 128MB
         // Alloc memory inside main memory
         uint8_t* componentMemory = static_cast<uint8_t*>(mainAllocator->allocBytes(size, sizeof(uint8_t)));
         ASSERT(componentMemory != nullptr, "Could not allocate component system memory");

--- a/src/atta/fileSystem/project/projectSerializer.cpp
+++ b/src/atta/fileSystem/project/projectSerializer.cpp
@@ -71,7 +71,6 @@ namespace atta
         // Deserialize version
         std::string version;
         read(is, version);
-        //LOG_DEBUG("ProjectSerializer", "Version: [w]$0", version);
         section.deserialize(is);
         is.close();
 
@@ -80,7 +79,6 @@ namespace atta
         deserializeConfig(section["config"]);
         deserializeComponentSystem(section["componentSystem"]);
         deserializeGraphicsSystem(section["graphicsSystem"]);
-        //LOG_DEBUG("ProjectSerializer", "Reading project: [w]$0", section);
     }
 }
 

--- a/src/atta/fileSystem/serializer/section.cpp
+++ b/src/atta/fileSystem/serializer/section.cpp
@@ -50,14 +50,14 @@ namespace atta
 
     void SectionData::serialize(std::ostream& os)
     {
-        write<size_t>(os, _data.size());
+        write<uint32_t>(os, _data.size());
         write(os, _data.data(), _data.size());
     }
 
     void SectionData::deserialize(std::istream& is)
     {
-        size_t size;
-        read<size_t>(is, size);
+        uint32_t size;
+        read<uint32_t>(is, size);
         _data.resize(size);
         if(size > 0)
             read(is, _data.data(), _data.size());
@@ -227,7 +227,7 @@ namespace atta
     {
         if(isUndefined()) 
         {
-            write<size_t>(os, 0);
+            write<uint32_t>(os, 0);
         }
         else if(isData())
         {
@@ -235,7 +235,7 @@ namespace atta
         }
         else if(isMap())
         {
-            write<size_t>(os, std::numeric_limits<size_t>::max());
+            write<uint32_t>(os, std::numeric_limits<uint32_t>::max());
             write<char>(os, '{');
             for(auto& [key, val] : map())
             {
@@ -246,7 +246,7 @@ namespace atta
         }
         else if(isVector())
         {
-            write<size_t>(os, std::numeric_limits<size_t>::max());
+            write<uint32_t>(os, std::numeric_limits<uint32_t>::max());
             write<char>(os, '[');
             unsigned i = 0;
             for(auto& el : vector())
@@ -270,15 +270,15 @@ namespace atta
             if(levels.back()->_type == UNDEFINED)
             {
                 // Discover type
-                size_t size;
+                uint32_t size;
                 std::streampos oldPos = is.tellg();
-                read<size_t>(is, size);
-                if(size == std::numeric_limits<size_t>::max())
+                read<uint32_t>(is, size);
+                if(size == std::numeric_limits<uint32_t>::max())
                 {
-                   // Section is map or vector
+                    // Section is map or vector
                     oldPos = is.tellg();
                     char open;
-                    read<char>(is, open);
+                    read(is, open);
                     if(open == '{')
                     {
                         // Section is map
@@ -292,7 +292,7 @@ namespace atta
                         levels.back()->_type = VECTOR;
                     }
                     else
-                        LOG_ERROR("FileSystem::Section", "Could not deserialize, was expecting [w]'{'[] or [w]'['[] but found [w]'$0'[]", open);
+                        LOG_ERROR("FileSystem::Section", "Could not deserialize, was expecting [w]'{'[] or [w]'['[] but found [w]'$0'[]", char(open));
                 }
                 else
                 {
@@ -307,7 +307,7 @@ namespace atta
             {
                 std::streampos oldPos = is.tellg();
                 char close;
-                read<char>(is, close);
+                read(is, close);
                 if(close == '}')
                 {
                     // Finished reading map
@@ -330,7 +330,7 @@ namespace atta
             else if(levels.back()->_type == VECTOR)
             {
                 char close;
-                read<char>(is, close);
+                read(is, close);
                 if(close == ']')
                 {
                     // Finished reading map

--- a/src/atta/graphicsSystem/rendererAPIs/openGL/openGLShaderGroup.cpp
+++ b/src/atta/graphicsSystem/rendererAPIs/openGL/openGLShaderGroup.cpp
@@ -107,27 +107,27 @@ namespace atta
         glUniform1f(getLoc(name), f);
     }
 
-    void OpenGLShaderGroup::setVec2(const char* name, const vec2& v)
+    void OpenGLShaderGroup::setVec2(const char* name, vec2 v)
     {
         glUniform2fv(getLoc(name), 1, &v.x);
     }
 
-    void OpenGLShaderGroup::setVec3(const char* name, const vec3& v)
+    void OpenGLShaderGroup::setVec3(const char* name, vec3 v)
     {
         glUniform3fv(getLoc(name), 1, &v.x);
     }
 
-    void OpenGLShaderGroup::setVec4(const char* name, const vec4& v)
+    void OpenGLShaderGroup::setVec4(const char* name, vec4 v)
     {
         glUniform4fv(getLoc(name), 1, &v.x);
     }
 
-    void OpenGLShaderGroup::setMat3(const char* name, const mat3& m)
+    void OpenGLShaderGroup::setMat3(const char* name, mat3 m)
     {
         glUniformMatrix3fv(getLoc(name), 1, GL_FALSE, m.data);
     }
 
-    void OpenGLShaderGroup::setMat4(const char* name, const mat4& m)
+    void OpenGLShaderGroup::setMat4(const char* name, mat4 m)
     {
         glUniformMatrix4fv(getLoc(name), 1, GL_FALSE, m.data);
     }

--- a/src/atta/graphicsSystem/rendererAPIs/openGL/openGLShaderGroup.h
+++ b/src/atta/graphicsSystem/rendererAPIs/openGL/openGLShaderGroup.h
@@ -24,11 +24,11 @@ namespace atta
         void setBool(const char* name, bool b) override;
         void setInt(const char* name, int i) override;
         void setFloat(const char* name, float f) override;
-        void setVec2(const char* name, const vec2& v) override;
-        void setVec3(const char* name, const vec3& v) override;
-        void setVec4(const char* name, const vec4& v) override;
-        void setMat3(const char* name, const mat3& m) override;
-        void setMat4(const char* name, const mat4& m) override;
+        void setVec2(const char* name, vec2 v) override;
+        void setVec3(const char* name, vec3 v) override;
+        void setVec4(const char* name, vec4 v) override;
+        void setMat3(const char* name, mat3 m) override;
+        void setMat4(const char* name, mat4 m) override;
         void setTexture(const char* name, StringId sid) override;
         void setTexture(const char* name, std::shared_ptr<Image> image) override;
         void setCubemap(const char* name, StringId sid) override;

--- a/src/atta/graphicsSystem/shaderGroup.h
+++ b/src/atta/graphicsSystem/shaderGroup.h
@@ -33,11 +33,11 @@ namespace atta
         virtual void setBool(const char* name, bool b) = 0;
         virtual void setInt(const char* name, int i) = 0;
         virtual void setFloat(const char* name, float f) = 0;
-        virtual void setVec2(const char* name, const vec2& v) = 0;
-        virtual void setVec3(const char* name, const vec3& v) = 0;
-        virtual void setVec4(const char* name, const vec4& v) = 0;
-        virtual void setMat3(const char* name, const mat3& m) = 0;
-        virtual void setMat4(const char* name, const mat4& m) = 0;
+        virtual void setVec2(const char* name, vec2 v) = 0;
+        virtual void setVec3(const char* name, vec3 v) = 0;
+        virtual void setVec4(const char* name, vec4 v) = 0;
+        virtual void setMat3(const char* name, mat3 m) = 0;
+        virtual void setMat4(const char* name, mat4 m) = 0;
         virtual void setTexture(const char* name, StringId sid) = 0;
         virtual void setTexture(const char* name, std::shared_ptr<Image> image) = 0;
         virtual void setCubemap(const char* name, StringId sid) = 0;

--- a/src/atta/resourceSystem/resourceManager.cpp
+++ b/src/atta/resourceSystem/resourceManager.cpp
@@ -25,7 +25,7 @@ namespace atta
         //----- System Memory -----//
         // Get main memory
         Allocator* mainAllocator = MemoryManager::getAllocator(SSID("MainAllocator"));
-        size_t size = 512*1024*1024;// 512MB
+        size_t size = 128*1024*1024;// 128MB
         // Alloc memory inside main memory
         uint8_t* resourceMemory = static_cast<uint8_t*>(mainAllocator->allocBytes(size, sizeof(uint8_t)));
         _allocator = new BitmapAllocator(resourceMemory, size);

--- a/src/atta/scriptSystem/.gitignore
+++ b/src/atta/scriptSystem/.gitignore
@@ -1,0 +1,1 @@
+scripts.h

--- a/src/atta/scriptSystem/CMakeLists.txt
+++ b/src/atta/scriptSystem/CMakeLists.txt
@@ -4,13 +4,18 @@ set(ATTA_SCRIPT_SYSTEM_SOURCE
     scriptManager.cpp
     script.cpp
     projectScript.cpp
-    compilers/compiler.cpp
-    compilers/nullCompiler.cpp
-    compilers/linuxCompiler.cpp
-    linkers/linker.cpp
-    linkers/nullLinker.cpp
-    linkers/linuxLinker.cpp
 )
+if(NOT ATTA_STATIC_PROJECT)
+    set(ATTA_SCRIPT_SYSTEM_DYNAMIC_SOURCE
+        compilers/compiler.cpp
+        compilers/nullCompiler.cpp
+        compilers/linuxCompiler.cpp
+        linkers/linker.cpp
+        linkers/nullLinker.cpp
+        linkers/linuxLinker.cpp
+    )
+    list(APPEND ATTA_SCRIPT_SYSTEM_SOURCE ${ATTA_SCRIPT_SYSTEM_DYNAMIC_SOURCE})
+endif()
 
 add_library(atta_script_system STATIC ${ATTA_SCRIPT_SYSTEM_SOURCE})
 atta_target_common(atta_script_system)

--- a/src/atta/scriptSystem/linkers/linker.h
+++ b/src/atta/scriptSystem/linkers/linker.h
@@ -18,7 +18,7 @@ namespace atta
         Linker() = default;
         virtual ~Linker() = default;
 
-        virtual void linkTarget(StringId target, Script** script, ProjectScript** projectScript) = 0;
+        virtual void linkTarget(StringId target, Script** script, ProjectScript** projectScript, std::string& name) = 0;
         virtual void releaseTarget(StringId target) = 0;
     };
 }

--- a/src/atta/scriptSystem/linkers/linuxLinker.h
+++ b/src/atta/scriptSystem/linkers/linuxLinker.h
@@ -17,7 +17,7 @@ namespace atta
         LinuxLinker() = default;
         ~LinuxLinker() = default;
 
-        void linkTarget(StringId target, Script** script, ProjectScript** projectScript) override;
+        void linkTarget(StringId target, Script** script, ProjectScript** projectScript, std::string& name) override;
         void releaseTarget(StringId target) override;
 
     private:

--- a/src/atta/scriptSystem/linkers/nullLinker.cpp
+++ b/src/atta/scriptSystem/linkers/nullLinker.cpp
@@ -8,9 +8,10 @@
 
 namespace atta
 {
-    void NullLinker::linkTarget(StringId target, Script** script, ProjectScript** projectScript)
+    void NullLinker::linkTarget(StringId target, Script** script, ProjectScript** projectScript, std::string& name)
     {
         *script = nullptr;
         *projectScript = nullptr;
+        name = "";
     }
 }

--- a/src/atta/scriptSystem/linkers/nullLinker.h
+++ b/src/atta/scriptSystem/linkers/nullLinker.h
@@ -16,7 +16,7 @@ namespace atta
         NullLinker() = default;
         ~NullLinker() = default;
 
-        void linkTarget(StringId target, Script** script, ProjectScript** projectScript) override;
+        void linkTarget(StringId target, Script** script, ProjectScript** projectScript, std::string& name) override;
         virtual void releaseTarget(StringId target) override {};
     };
 }

--- a/src/atta/scriptSystem/projectScript.h
+++ b/src/atta/scriptSystem/projectScript.h
@@ -35,14 +35,21 @@ namespace atta
         //---------- While ----------//
         virtual void onAttaLoop() {};
     }; 
-}
 
-#define ATTA_REGISTER_PROJECT_SCRIPT(DerivedProjectScript) \
-extern "C" {\
-    atta::ProjectScript* createProjectScript()\
-    {\
-        return static_cast<atta::ProjectScript*>(new DerivedProjectScript());\
-    }\
+#ifdef ATTA_STATIC_PROJECT
+    template<typename T> class ProjectScriptRegistration { static ProjectScript* reg; };
+#define ATTA_REGISTER_PROJECT_SCRIPT(TYPE) \
+    template<> inline ::atta::Script* ::atta::ProjectScriptRegistration<TYPE>::reg = ::atta::ScriptManager::registerProjectScript(#TYPE, new TYPE());
+#else
+#define ATTA_REGISTER_PROJECT_SCRIPT(TYPE) \
+    extern "C" {\
+        std::pair<std::string, atta::ProjectScript*> createProjectScript()\
+        {\
+            return { #TYPE, static_cast<atta::ProjectScript*>(new TYPE()) };\
+        }\
+    }
+#endif
+
 }
 
 #endif// ATTA_SCRIPT_SYSTEM_PROJECT_SCRIPT_H

--- a/src/atta/scriptSystem/script.h
+++ b/src/atta/scriptSystem/script.h
@@ -18,14 +18,23 @@ namespace atta
 		virtual ~Script() {};  
 		virtual void update(Entity entity, float dt) = 0;
 	}; 
+
+#ifdef ATTA_STATIC_PROJECT
+    template<typename T> class ScriptRegistration { static Script* reg; };
+#define ATTA_REGISTER_SCRIPT(TYPE) \
+    template<> \
+    inline ::atta::Script* ::atta::ScriptRegistration<TYPE>::reg = ::atta::ScriptManager::registerScript(#TYPE, new TYPE());
+#else
+#define ATTA_REGISTER_SCRIPT(TYPE) \
+    extern "C" {\
+        std::pair<std::string, atta::Script*> createScript()\
+        {\
+            return { #TYPE, static_cast<atta::Script*>(new TYPE()) };\
+        }\
+    }
+#endif
+
 }
 
-#define ATTA_REGISTER_SCRIPT(DerivedScript) \
-extern "C" {\
-    atta::Script* createScript()\
-    {\
-        return static_cast<atta::Script*>(new DerivedScript());\
-    }\
-}
 
 #endif// ATTA_SCRIPT_SYSTEM_SCRIPT_H

--- a/src/atta/scriptSystem/scriptManager.cpp
+++ b/src/atta/scriptSystem/scriptManager.cpp
@@ -35,8 +35,6 @@ namespace atta
         for(auto [script, value] : _scripts)
             if(script != _projectScript.first)
                 scripts.push_back(script);
-
-        LOG_DEBUG("ScriptManager", "Scripts: $0", scripts);
         return scripts;
     }
 

--- a/src/atta/scriptSystem/scriptManager.cpp
+++ b/src/atta/scriptSystem/scriptManager.cpp
@@ -6,17 +6,7 @@
 //--------------------------------------------------
 #include <atta/scriptSystem/scriptManager.h>
 #include <atta/eventSystem/eventManager.h>
-#include <atta/eventSystem/events/fileWatchEvent.h>
-#include <atta/eventSystem/events/projectBeforeDeserializeEvent.h>
-#include <atta/eventSystem/events/projectOpenEvent.h>
-#include <atta/eventSystem/events/projectCloseEvent.h>
 #include <atta/eventSystem/events/scriptTargetEvent.h>
-#include <atta/scriptSystem/compilers/nullCompiler.h>
-#include <atta/scriptSystem/compilers/linuxCompiler.h>
-#include <atta/scriptSystem/linkers/nullLinker.h>
-#include <atta/scriptSystem/linkers/linuxLinker.h>
-
-#include <atta/componentSystem/componentManager.h>
 
 namespace atta
 {
@@ -24,31 +14,6 @@ namespace atta
     {
         static ScriptManager instance;
         return instance;
-    }
-
-    void ScriptManager::startUp() { getInstance().startUpImpl(); }
-    void ScriptManager::startUpImpl()
-    {
-#ifdef ATTA_OS_LINUX
-        _compiler = std::static_pointer_cast<Compiler>(std::make_shared<LinuxCompiler>());
-        _linker = std::static_pointer_cast<Linker>(std::make_shared<LinuxLinker>());
-#else
-        _compiler = std::static_pointer_cast<Compiler>(std::make_shared<NullCompiler>());
-        _linker = std::static_pointer_cast<Linker>(std::make_shared<NullLinker>());
-#endif
-
-        EventManager::subscribe<FileWatchEvent>(BIND_EVENT_FUNC(ScriptManager::onFileChange));
-        EventManager::subscribe<ProjectBeforeDeserializeEvent>(BIND_EVENT_FUNC(ScriptManager::onProjectOpen));
-        EventManager::subscribe<ProjectOpenEvent>(BIND_EVENT_FUNC(ScriptManager::onProjectOpen));
-        EventManager::subscribe<ProjectCloseEvent>(BIND_EVENT_FUNC(ScriptManager::onProjectClose));
-
-        _projectScript = std::make_pair(StringId(), nullptr);
-    }
-
-    void ScriptManager::shutDown() { getInstance().shutDownImpl(); }
-    void ScriptManager::shutDownImpl()
-    {
-
     }
 
     Script* ScriptManager::getScript(StringId target) { return getInstance().getScriptImpl(target); } 
@@ -71,7 +36,7 @@ namespace atta
             if(script != _projectScript.first)
                 scripts.push_back(script);
 
-        //LOG_DEBUG("ScriptManager", "Scripts: $0", scripts);
+        LOG_DEBUG("ScriptManager", "Scripts: $0", scripts);
         return scripts;
     }
 
@@ -86,117 +51,10 @@ namespace atta
     {
         return _projectScript.first;
     }
-
-    void ScriptManager::onFileChange(Event& event)
-    {
-        FileWatchEvent& e = reinterpret_cast<FileWatchEvent&>(event);
-
-        if(e.file.filename() == "CMakeLists.txt")
-        {
-            updateAllTargets();
-            return;
-        }
-
-        for(auto target : _compiler->getTargetFiles())
-            for(auto file : target.second)
-                if(file == e.file)
-                    updateTarget(target.first);
-
-        // Publish event
-        ScriptTargetEvent evt;
-        evt.scriptSids = getScriptSids();
-        EventManager::publish(evt);
-    }
-
-    void ScriptManager::onProjectOpen(Event& event)
-    {
-        updateAllTargets();
-
-        // Publish event
-        ScriptTargetEvent evt;
-        evt.scriptSids = getScriptSids();
-        EventManager::publish(evt);
-    }
-
-    void ScriptManager::onProjectClose(Event& event)
-    {
-        // Release all targets
-        for(auto target : _compiler->getTargets())
-            releaseTarget(target);
-
-        // Publish event
-        ScriptTargetEvent evt;
-        evt.scriptSids = getScriptSids();
-        EventManager::publish(evt);
-    }
-
-    void ScriptManager::updateAllTargets()
-    {
-        // Release all targets
-        for(auto target : _compiler->getTargets())
-            releaseTarget(target);
-
-        // Recompile all targets
-        _compiler->compileAll();
-        _compiler->updateTargets();
-
-        // Link each target in the project
-        for(auto target : _compiler->getTargets())
-            linkTarget(target);
-
-        //LOG_DEBUG("ScriptManager", "Targets updated: $0", _compiler->getTargets());
-    }
-
-    void ScriptManager::updateTarget(StringId target)
-    {
-        // Delete all scripts related to this target
-        releaseTarget(target);
-
-        // Compile and link specific target
-        _compiler->compileTarget(target);
-
-        // Link target
-        linkTarget(target);
-    }
-
-    void ScriptManager::linkTarget(StringId target)
-    {
-        Script* script = nullptr;
-        ProjectScript* projectScript = nullptr;
-        _linker->linkTarget(target, &script, &projectScript);
-        if(script != nullptr)
-            _scripts[target] = script;
-
-        if(projectScript != nullptr)
-        {
-            if(_projectScript.second != nullptr)
-                LOG_WARN("ScriptManager", "Multiple project scripts found. There must be only one project script in the project. Found at [w]$0[] and [w]$1[]", _projectScript.first, target);
-            _projectScript.first = target;
-            _projectScript.second = projectScript;
-
-            _projectScript.second->onLoad();
-        }
-    }
-
-    void ScriptManager::releaseTarget(StringId target)
-    {
-        // Delete script
-        if(_scripts.find(target) != _scripts.end())
-            delete _scripts[target];
-        _scripts.erase(target);
-
-        // Delete project script
-        if(_projectScript.first == target)
-        {
-            _projectScript.second->onUnload();
-            //ComponentManager::unregisterCustomComponents();
-
-            _projectScript.first = StringId();
-            delete _projectScript.second;
-            _projectScript.second = nullptr;
-        }
-
-        // Release target
-        _linker->releaseTarget(target);
-    }
 }
+
+#ifdef ATTA_STATIC_PROJECT
+#include <atta/scriptSystem/scriptManagerStatic.cpp>
+#else
+#include <atta/scriptSystem/scriptManagerDynamic.cpp>
+#endif

--- a/src/atta/scriptSystem/scriptManager.h
+++ b/src/atta/scriptSystem/scriptManager.h
@@ -6,9 +6,13 @@
 //--------------------------------------------------
 #ifndef ATTA_SCRIPT_SYSTEM_SCRIPT_MANAGER_H
 #define ATTA_SCRIPT_SYSTEM_SCRIPT_MANAGER_H
+#include <atta/scriptSystem/script.h>
+#include <atta/scriptSystem/projectScript.h>
+#ifndef ATTA_STATIC_PROJECT
 #include <atta/eventSystem/event.h>
 #include <atta/scriptSystem/compilers/compiler.h>
 #include <atta/scriptSystem/linkers/linker.h>
+#endif
 
 namespace atta
 {
@@ -25,6 +29,11 @@ namespace atta
         static ProjectScript* getProjectScript();
         static StringId getProjectScriptSid();
 
+#ifdef ATTA_STATIC_PROJECT
+        static ProjectScript* registerProjectScript(std::string name, ProjectScript* projectScript);
+        static Script* registerScript(std::string name, Script* script);
+#endif
+
     private:
         void startUpImpl();
         void shutDownImpl();
@@ -35,6 +44,7 @@ namespace atta
         ProjectScript* getProjectScriptImpl() const;
         StringId getProjectScriptSidImpl() const;
 
+#ifndef ATTA_STATIC_PROJECT
         // Handle events
         void onFileChange(Event& event);
         void onProjectOpen(Event& event);
@@ -47,10 +57,11 @@ namespace atta
 
         std::shared_ptr<Compiler> _compiler;
         std::shared_ptr<Linker> _linker;
+        std::map<StringId, StringId> _targetToScript;// Convert target name to script name
+#endif
 
         std::unordered_map<StringId, Script*> _scripts;
         std::pair<StringId, ProjectScript*> _projectScript;
-
     };
 }
 

--- a/src/atta/scriptSystem/scriptManagerDynamic.cpp
+++ b/src/atta/scriptSystem/scriptManagerDynamic.cpp
@@ -1,0 +1,162 @@
+//--------------------------------------------------
+// Atta Script System
+// scriptManagerDynamic.cpp
+// Date: 2022-06-12
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+#include <atta/eventSystem/events/fileWatchEvent.h>
+#include <atta/eventSystem/events/projectBeforeDeserializeEvent.h>
+#include <atta/eventSystem/events/projectOpenEvent.h>
+#include <atta/eventSystem/events/projectCloseEvent.h>
+#include <atta/scriptSystem/compilers/nullCompiler.h>
+#include <atta/scriptSystem/compilers/linuxCompiler.h>
+#include <atta/scriptSystem/linkers/nullLinker.h>
+#include <atta/scriptSystem/linkers/linuxLinker.h>
+#include <atta/componentSystem/componentManager.h>
+
+namespace atta
+{
+    void ScriptManager::startUp() { getInstance().startUpImpl(); }
+    void ScriptManager::startUpImpl()
+    {
+#ifdef ATTA_OS_LINUX
+        _compiler = std::static_pointer_cast<Compiler>(std::make_shared<LinuxCompiler>());
+        _linker = std::static_pointer_cast<Linker>(std::make_shared<LinuxLinker>());
+#else
+        _compiler = std::static_pointer_cast<Compiler>(std::make_shared<NullCompiler>());
+        _linker = std::static_pointer_cast<Linker>(std::make_shared<NullLinker>());
+#endif
+
+        EventManager::subscribe<FileWatchEvent>(BIND_EVENT_FUNC(ScriptManager::onFileChange));
+        EventManager::subscribe<ProjectBeforeDeserializeEvent>(BIND_EVENT_FUNC(ScriptManager::onProjectOpen));
+        EventManager::subscribe<ProjectOpenEvent>(BIND_EVENT_FUNC(ScriptManager::onProjectOpen));
+        EventManager::subscribe<ProjectCloseEvent>(BIND_EVENT_FUNC(ScriptManager::onProjectClose));
+
+        _projectScript = std::make_pair(StringId(), nullptr);
+    }
+
+    void ScriptManager::shutDown() { getInstance().shutDownImpl(); }
+    void ScriptManager::shutDownImpl()
+    {
+
+    }
+
+    void ScriptManager::onFileChange(Event& event)
+    {
+        FileWatchEvent& e = reinterpret_cast<FileWatchEvent&>(event);
+
+        if(e.file.filename() == "CMakeLists.txt")
+        {
+            updateAllTargets();
+            return;
+        }
+
+        for(auto target : _compiler->getTargetFiles())
+            for(auto file : target.second)
+                if(file == e.file)
+                    updateTarget(target.first);
+
+        // Publish event
+        ScriptTargetEvent evt;
+        evt.scriptSids = getScriptSids();
+        EventManager::publish(evt);
+    }
+
+    void ScriptManager::onProjectOpen(Event& event)
+    {
+        updateAllTargets();
+
+        // Publish event
+        ScriptTargetEvent evt;
+        evt.scriptSids = getScriptSids();
+        EventManager::publish(evt);
+    }
+
+    void ScriptManager::onProjectClose(Event& event)
+    {
+        // Release all targets
+        for(auto target : _compiler->getTargets())
+            releaseTarget(target);
+
+        // Publish event
+        ScriptTargetEvent evt;
+        evt.scriptSids = getScriptSids();
+        EventManager::publish(evt);
+    }
+
+    void ScriptManager::updateAllTargets()
+    {
+        // Release all targets
+        for(auto target : _compiler->getTargets())
+            releaseTarget(target);
+
+        // Recompile all targets
+        _compiler->compileAll();
+        _compiler->updateTargets();
+
+        // Link each target in the project
+        for(auto target : _compiler->getTargets())
+            linkTarget(target);
+        //LOG_DEBUG("ScriptManager", "Targets updated: $0", _compiler->getTargets());
+    }
+
+    void ScriptManager::updateTarget(StringId target)
+    {
+        // Delete all scripts related to this target
+        releaseTarget(target);
+
+        // Compile and link specific target
+        _compiler->compileTarget(target);
+
+        // Link target
+        linkTarget(target);
+    }
+
+    void ScriptManager::linkTarget(StringId target)
+    {
+        Script* script = nullptr;
+        ProjectScript* projectScript = nullptr;
+        std::string name;
+        _linker->linkTarget(target, &script, &projectScript, name);
+        if(script != nullptr)
+            _scripts[StringId(name)] = script;
+
+        if(projectScript != nullptr)
+        {
+            if(_projectScript.second != nullptr)
+                LOG_WARN("ScriptManager", "Multiple project scripts found. There must be only one project script in the project. Found at [w]$0[] and [w]$1[]", _projectScript.first, target);
+
+            _projectScript.first = StringId(name);
+            _projectScript.second = projectScript;
+
+            _projectScript.second->onLoad();
+        }
+
+        if(script || projectScript)
+            _targetToScript[target] = StringId(name);
+    }
+
+    void ScriptManager::releaseTarget(StringId target)
+    {
+        // Delete script
+        if(_scripts.find(_targetToScript[target]) != _scripts.end())
+            delete _scripts[_targetToScript[target]];
+        _scripts.erase(_targetToScript[target]);
+
+        // Delete project script
+        if(_projectScript.first == _targetToScript[target])
+        {
+            _projectScript.second->onUnload();
+            //ComponentManager::unregisterCustomComponents();
+
+            _projectScript.first = StringId();
+            delete _projectScript.second;
+            _projectScript.second = nullptr;
+        }
+
+        _targetToScript.erase(target);
+
+        // Release target
+        _linker->releaseTarget(target);
+    }
+}

--- a/src/atta/scriptSystem/scriptManagerStatic.cpp
+++ b/src/atta/scriptSystem/scriptManagerStatic.cpp
@@ -1,0 +1,48 @@
+//--------------------------------------------------
+// Atta Script System
+// scriptManagerStatic.cpp
+// Date: 2022-06-12
+// By Breno Cunha Queiroz
+//--------------------------------------------------
+#include <atta/scriptSystem/scripts.h>
+
+namespace atta
+{
+    void ScriptManager::startUp() { getInstance().startUpImpl(); }
+    void ScriptManager::startUpImpl()
+    {
+        // Publish registered scripts. Need to do here because scripts are 
+        // registered before ComponentSystem::startUp())
+        ScriptTargetEvent evt;
+        evt.scriptSids = getScriptSids();
+        EventManager::publish(evt);
+    }
+
+    void ScriptManager::shutDown() { getInstance().shutDownImpl(); }
+    void ScriptManager::shutDownImpl()
+    {
+        if(_projectScript.second != nullptr)
+            delete _projectScript.second;
+
+        for(auto& [key, s] : _scripts)
+            delete s;
+        _scripts.clear();
+    }
+
+    ProjectScript* ScriptManager::registerProjectScript(std::string name, ProjectScript* projectScript)
+    {
+        LOG_VERBOSE("ScriptManager", "Registering project script [w]$0[]", name);
+        getInstance()._projectScript.first = StringId(name);
+        getInstance()._projectScript.second = projectScript;
+
+        return projectScript;
+    }
+
+    Script* ScriptManager::registerScript(std::string name, Script* script)
+    {
+        LOG_VERBOSE("ScriptManager", "Registering script [w]$0[]", name);
+        getInstance()._scripts[StringId(name)] = script;
+
+        return script;
+    }
+}

--- a/src/atta/scriptSystem/scripts.h.in
+++ b/src/atta/scriptSystem/scripts.h.in
@@ -1,12 +1,13 @@
 //--------------------------------------------------
 // Atta - Script System
-// scripts.h           
+// scripts.h
 // Date: 2022-06-12
 // By Breno Cunha Queiroz  
 //--------------------------------------------------
 #ifndef ATTA_SCRIPT_SYSTEM_SCRIPTS   
 #define ATTA_SCRIPT_SYSTEM_SCRIPTS   
 
+// Include scripts from the project
 @ATTA_STATIC_PROJECT_SCRIPTS@
 
 #endif// ATTA_SCRIPT_SYSTEM_SCRIPTS

--- a/src/atta/scriptSystem/scripts.h.in
+++ b/src/atta/scriptSystem/scripts.h.in
@@ -1,0 +1,12 @@
+//--------------------------------------------------
+// Atta - Script System
+// scripts.h           
+// Date: 2022-06-12
+// By Breno Cunha Queiroz  
+//--------------------------------------------------
+#ifndef ATTA_SCRIPT_SYSTEM_SCRIPTS   
+#define ATTA_SCRIPT_SYSTEM_SCRIPTS   
+
+@ATTA_STATIC_PROJECT_SCRIPTS@
+
+#endif// ATTA_SCRIPT_SYSTEM_SCRIPTS

--- a/src/atta/uiSystem/CMakeLists.txt
+++ b/src/atta/uiSystem/CMakeLists.txt
@@ -31,6 +31,6 @@ add_library(atta_ui_system STATIC
     ${ATTA_UI_SYSTEM_SOURCE}
 )
 
-target_link_libraries(atta_ui_system PRIVATE atta_graphics_system atta_io_system atta_cv atta_component_system ${ATTA_IMGUIZMO_TARGETS} ${ATTA_CPPNETSDK_TARGETS})
+target_link_libraries(atta_ui_system PRIVATE atta_graphics_system atta_io_system atta_cv atta_component_system ${ATTA_IMGUIZMO_TARGETS})
 atta_target_common(atta_ui_system)
 atta_add_libs(atta_ui_system)

--- a/src/atta/uiSystem/layers/editor/topBar/topBar.cpp
+++ b/src/atta/uiSystem/layers/editor/topBar/topBar.cpp
@@ -37,16 +37,18 @@ namespace atta::ui
         {
             if(ImGui::BeginMenu("File"))
             {
-
                 if(FileManager::isProjectOpen())
                 {
                     ImGui::Text(FileManager::getProject()->getName().c_str());
                     ImGui::Separator();
 
+#ifndef ATTA_STATIC_PROJECT
                     if(ImGui::MenuItem("Close"))
 						_showSaveProject = true;
+#endif
                 }
 
+#ifndef ATTA_STATIC_PROJECT
                 if(ImGui::BeginMenu("Open"))
                 {
                     if(ImGui::MenuItem("From file"))
@@ -59,14 +61,17 @@ namespace atta::ui
 
                     ImGui::EndMenu();
                 }
+#endif
 
 
                 if(FileManager::isProjectOpen())
                     if(ImGui::MenuItem("Save"))
                         FileManager::saveProject();
 
+#ifndef ATTA_STATIC_PROJECT
                 if(ImGui::MenuItem("Save as"))
                     _showCreateProject = true;
+#endif
 
                 ImGui::Separator();
 

--- a/src/atta/uiSystem/layers/uiLayer.cpp
+++ b/src/atta/uiSystem/layers/uiLayer.cpp
@@ -27,8 +27,8 @@ namespace atta::ui
         ImGui::CreateContext();
 
         ImGuiIO& io = ImGui::GetIO(); (void)io;
-        io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
-        io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
+        io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;// Enable Keyboard Controls
+        io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;// Enable Docking
 
         // Don't save imgui.ini
         io.IniFilename = NULL;
@@ -37,13 +37,13 @@ namespace atta::ui
         io.IniFilename = NULL;
 #else
         // Multiple viewports not supported for the web
-        io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows
+        io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;// Enable Multi-Viewport
 #endif
 
-        setTheme();
         GLFWwindow* window = glfwGetCurrentContext();
         ImGui_ImplGlfw_InitForOpenGL(window, true);
         ImGui_ImplOpenGL3_Init("#version 100");
+        setTheme();
     }
 
     void UILayer::onDetach()

--- a/src/extern/solveAssimp.cmake
+++ b/src/extern/solveAssimp.cmake
@@ -1,19 +1,19 @@
 set(ATTA_ASSIMP_SUPPORT FALSE)
 set(ATTA_ASSIMP_TARGETS "")
 
-find_package(assimp)
-# TODO work with installed assimp
-if(assimp_FOUND AND FALSE)
-    atta_log(Success Extern "Assimp support (installed)")
-
-    set(ATTA_ASSIMP_TARGETS ${ASSIMP_LIBRARIES})
-    set(ATTA_ASSIMP_SUPPORT TRUE)
-
-    # TODO Fix assimp include (not working yet, directory must exist to compile)
-    #get_property(fix_assimp_includes TARGET ${ATTA_ASSIMP_TARGETS} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-    #list(REMOVE_ITEM fix_assimp_includes "/usr/local/src/extern")
-    #set_property(TARGET ${ATTA_ASSIMP_TARGETS} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${fix_assimp_includes})
-else()
+#find_package(assimp)
+## TODO work with installed assimp
+#if(assimp_FOUND AND FALSE)
+#    atta_log(Success Extern "Assimp support (installed)")
+#
+#    set(ATTA_ASSIMP_TARGETS ${ASSIMP_LIBRARIES})
+#    set(ATTA_ASSIMP_SUPPORT TRUE)
+#
+#    # TODO Fix assimp include (not working yet, directory must exist to compile)
+#    #get_property(fix_assimp_includes TARGET ${ATTA_ASSIMP_TARGETS} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+#    #list(REMOVE_ITEM fix_assimp_includes "/usr/local/src/extern")
+#    #set_property(TARGET ${ATTA_ASSIMP_TARGETS} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${fix_assimp_includes})
+#else()
     set(ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT FALSE CACHE INTERNAL "" FORCE)
     set(ASSIMP_BUILD_ASSIMP_TOOLS OFF CACHE INTERNAL "" FORCE)
     set(ASSIMP_BUILD_OBJ_IMPORTER TRUE CACHE INTERNAL "" FORCE)
@@ -40,4 +40,4 @@ else()
     atta_log(Success Extern "Assimp support (source)")
     set(ATTA_ASSIMP_SUPPORT TRUE)
     set(ATTA_ASSIMP_TARGETS assimp)
-endif()
+#endif()

--- a/src/extern/solveCurlpp.cmake
+++ b/src/extern/solveCurlpp.cmake
@@ -1,24 +1,26 @@
 set(ATTA_CURLPP_SUPPORT FALSE)
 set(ATTA_CURLPP_TARGETS "")
 
-find_package(CURL)
-if((ATTA_SYSTEM_NAME MATCHES "Linux") AND CURL_FOUND)
-    FetchContent_Declare(
-        curlpp
-        GIT_REPOSITORY "https://github.com/jpbarrette/curlpp"
-        GIT_TAG "236a1c5c116f68fd7c8ba9be5edbf492824e5295"
-        GIT_PROGRESS TRUE
-    )
-    atta_log(Info Extern "Fetching curlpp...")
-    atta_FetchContent_MakeAvailable(curlpp) 
+if(ATTA_SYSTEM_NAME MATCHES "Linux")
+    find_package(CURL)
+    if(CURL_FOUND)
+        FetchContent_Declare(
+            curlpp
+            GIT_REPOSITORY "https://github.com/jpbarrette/curlpp"
+            GIT_TAG "236a1c5c116f68fd7c8ba9be5edbf492824e5295"
+            GIT_PROGRESS TRUE
+        )
+        atta_log(Info Extern "Fetching curlpp...")
+        atta_FetchContent_MakeAvailable(curlpp) 
 
-    # Fix INTERFACE_INCLUDE_DIRECTORIES to not include local build
-    set_property(TARGET curlpp_static PROPERTY INTERFACE_INCLUDE_DIRECTORIES "")
+        # Fix INTERFACE_INCLUDE_DIRECTORIES to not include local build
+        set_property(TARGET curlpp_static PROPERTY INTERFACE_INCLUDE_DIRECTORIES "")
 
-    atta_log(Success Extern "curlpp supported (source)")
-    set(ATTA_CURLPP_SUPPORT TRUE)
-    set(ATTA_CURLPP_TARGETS curlpp_static)
-    atta_add_libs(${ATTA_CURLPP_TARGETS})
+        atta_log(Success Extern "curlpp supported (source)")
+        set(ATTA_CURLPP_SUPPORT TRUE)
+        set(ATTA_CURLPP_TARGETS curlpp_static)
+        atta_add_libs(${ATTA_CURLPP_TARGETS})
+    endif()
 endif()
 
 if(ATTA_CURLPP_SUPPORT)

--- a/src/extern/solveImgui.cmake
+++ b/src/extern/solveImgui.cmake
@@ -4,7 +4,7 @@ set(ATTA_IMGUI_TARGETS "")
 FetchContent_Declare(
     imgui
     GIT_REPOSITORY "https://github.com/ocornut/imgui"
-    GIT_TAG "ec1e57ed4a616ee42f4711b4a955bc68b9c1f463"
+    GIT_TAG "e900ca355e3c7be7672e25800af346f1179e91d8"
     GIT_PROGRESS TRUE
 )
 


### PR DESCRIPTION
Now it is possible to run projects with the web build!

To do that it was necessary to compile atta linked statically to the project. Also, the project `.atta` file and `resources/` folder are copied to the web build. When `find_package(atta)` is called by the project, the current atta build is used instead of the installed one. It is not possible to install atta to the machine when it is built statically linked to a project or when building the web build.

Example compiling and running **dynamic project**:
```bash
cd atta/build
cmake ..
make -j
bin/atta <path to .atta>
```

Example compiling and running **static project**:
```bash
cd atta/build
cmake -DATTA_STATIC_PROJECT_FILE=<path to .atta> ..
make -j
bin/atta
```

Example compiling and running **web project**:
```bash
cd atta/build
emcmake cmake -DATTA_STATIC_PROJECT_FILE=<path to .atta> ..
make -j
emrun bin/atta.html
```

Yes, that easy!
<p align="center">
  <img src="https://user-images.githubusercontent.com/17342434/173412167-1b969635-34ec-4245-a8af-b0a8fe2d7f7f.gif" />
</p>

Next step will be integrate this new feature with https://atta.brenocq.com/build to execute published projects.
For implementation details check issue #17.