### PR TITLE
 Automate versioning with GitHub actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,11 +6,6 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to run CI on"
-        required: false
-        default: main
 
 jobs:
   build:
@@ -26,8 +21,6 @@ jobs:
     steps:
       - name: Checkout atta
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,16 @@
-name: Linux
-on: [push, pull_request, release]
+name: 🐧 Linux
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to run CI on"
+        required: false
+        default: main
 
 jobs:
   build:
@@ -9,20 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {
-          name: "Ubuntu g++",
-          os: ubuntu-latest,
-          compiler: "g++"
-        }
-        - {
-          name: "Ubuntu clang++",
-          os: ubuntu-latest,
-          compiler: "clang++"
-        }
+        - { name: "Ubuntu g++", os: ubuntu-latest, compiler: "g++" }
+        - { name: "Ubuntu clang++", os: ubuntu-latest, compiler: "clang++" }
 
     steps:
       - name: Checkout atta
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,16 @@
-name: MacOS
-on: [push, pull_request, release]
+name: 🍎 MacOS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to run CI on"
+        required: false
+        default: main
 
 jobs:
   build:
@@ -9,15 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {
-          name: "MacOS Latest",
-          os: macos-latest,
-          build_type: "Release"
-        }
+        - { name: "MacOS Latest", os: macos-latest, build_type: "Release" }
 
     steps:
       - name: Checkout atta
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Install dependencies on macos
         if: startsWith(matrix.config.os, 'macos')

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,11 +6,6 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to run CI on"
-        required: false
-        default: main
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout atta
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Install dependencies on macos
         if: startsWith(matrix.config.os, 'macos')

--- a/.github/workflows/updateReadmeButtons.yml
+++ b/.github/workflows/updateReadmeButtons.yml
@@ -1,4 +1,4 @@
-name: Update readme buttons
+name: 📄 Update README
 
 on:
   project_card:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -125,10 +125,12 @@ jobs:
         run: |
           # Fetch the PR title from GitHub event payload
           PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
           echo "::notice::PR Title: $PR_TITLE"
+          echo "::notice::PR Number: $PR_NUMBER"
 
           # Create an annotated tag with the PR title as the description
-          git tag -a "v$NEW_VERSION" -m "$PR_TITLE"
+          git tag -a "v$NEW_VERSION" -m "PR #$PR_NUMBER - $PR_TITLE"
 
           # Push the tag to the remote repository
           git push origin "v$NEW_VERSION"

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -3,16 +3,16 @@ name: 🏷️ Auto Versioning
 on:
   pull_request:
     types:
-      - synchronize  # XXX Temporary to test the workflow
-      #- closed  # Runs when PR is merged
+      - labeled  # Runs when labels are added to the PR
 
 jobs:
   versioning:
-    #if: github.event.pull_request.merged == true  # Only run if PR is merged
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history to enable merging
 
       - name: Set up Git
         run: |
@@ -28,8 +28,42 @@ jobs:
             console.log("PR Labels:", labels);
             return labels;
 
+      - name: Check if Version Label Exists
+        id: check_version_label
+        run: |
+          if echo "${{ steps.labels.outputs.result }}" | grep -Eq "version:(major|minor|patch)"; then
+            echo "run_versioning=true" >> $GITHUB_ENV
+          else
+            echo "No versioning label found. Skipping workflow."
+            exit 0
+          fi
+
+      - name: Merge `dev` into PR Branch
+        run: |
+          git fetch origin dev
+          git checkout ${{ github.head_ref }}
+          if git merge --no-edit origin/dev; then
+            echo "Merge successful."
+          else
+            echo "::error::Merge conflict detected! Resolve conflicts manually."
+            exit 1
+          fi
+        continue-on-error: false
+
+      - name: Get Current Version from `dev`
+        run: |
+          git checkout origin/dev -- CMakeLists.txt
+          VERSION=$(sed -nE 's/project\(atta VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt)
+
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Failed to extract version from CMakeLists.txt"
+            exit 1
+          fi
+
+          echo "::notice::Current Version (from dev): $VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Determine Version Increment
-        id: version_type
         run: |
           echo "::notice::PR Labels Found: ${{ steps.labels.outputs.result }}"
           if echo "${{ steps.labels.outputs.result }}" | grep -q "version:major"; then
@@ -43,18 +77,8 @@ jobs:
             echo "::notice::Version Increment: patch"
           fi
 
-      - name: Read and Increment Version
-        id: update_version
+      - name: Increment Version
         run: |
-          VERSION=$(sed -nE 's/project\(atta VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt)
-
-          if [[ -z "$VERSION" ]]; then
-            echo "::error::Failed to extract version from CMakeLists.txt"
-            exit 1
-          fi
-
-          echo "::notice::Current Version: $VERSION"
-
           IFS='.' read -r major minor patch <<< "$VERSION"
 
           case "$increment" in
@@ -67,15 +91,29 @@ jobs:
           echo "::notice::New Version: $NEW_VERSION"
 
           sed -i -E "s/(project\(atta VERSION) [0-9]+\.[0-9]+\.[0-9]+/\1 $NEW_VERSION/" CMakeLists.txt
-          echo "version=$NEW_VERSION" >> $GITHUB_ENV
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
-      - name: Commit and Push Updated Version
+      - name: Commit Updated Version (If Changed)
         run: |
           git add CMakeLists.txt
-          git commit --allow-empty -m "Chore: Bump version to ${{ env.version }}"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Chore: Bump version to $NEW_VERSION"
+            git push origin ${{ github.head_ref }}
+          fi
 
-      - name: Create Git Tag
+      - name: Delete Old Tag (If Exists)
         run: |
-          git tag "v${{ env.version }}"
-          git push origin "v${{ env.version }}"
+          if git rev-parse "v$NEW_VERSION" >/dev/null 2>&1; then
+            git push --delete origin "v$NEW_VERSION"
+            git tag -d "v$NEW_VERSION"
+            echo "Deleted existing tag v$NEW_VERSION."
+          else
+            echo "No existing tag v$NEW_VERSION found."
+          fi
+
+      - name: Create and Push New Git Tag
+        run: |
+          git tag "v$NEW_VERSION"
+          git push origin "v$NEW_VERSION"

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -123,5 +123,12 @@ jobs:
       - name: Create and Push New Git Tag
         if: env.run_versioning == 'true'
         run: |
-          git tag "v$NEW_VERSION"
+          # Fetch the PR title from GitHub event payload
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          echo "::notice::PR Title: $PR_TITLE"
+
+          # Create an annotated tag with the PR title as the description
+          git tag -a "v$NEW_VERSION" -m "$PR_TITLE"
+
+          # Push the tag to the remote repository
           git push origin "v$NEW_VERSION"

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   versioning:
+    name: Auto Versioning
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -34,11 +35,12 @@ jobs:
           if echo "${{ steps.labels.outputs.result }}" | grep -Eq "version:(major|minor|patch)"; then
             echo "run_versioning=true" >> $GITHUB_ENV
           else
-            echo "No versioning label found. Skipping workflow."
+            echo "::notice::No versioning label found. Skipping workflow."
             exit 0
           fi
 
       - name: Merge `dev` into PR Branch
+        if: env.run_versioning == 'true'
         run: |
           git fetch origin dev
           git checkout ${{ github.head_ref }}
@@ -51,6 +53,7 @@ jobs:
         continue-on-error: false
 
       - name: Get Current Version from `dev`
+        if: env.run_versioning == 'true'
         run: |
           git checkout origin/dev -- CMakeLists.txt
           VERSION=$(sed -nE 's/project\(atta VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt)
@@ -64,6 +67,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Determine Version Increment
+        if: env.run_versioning == 'true'
         run: |
           echo "::notice::PR Labels Found: ${{ steps.labels.outputs.result }}"
           if echo "${{ steps.labels.outputs.result }}" | grep -q "version:major"; then
@@ -78,6 +82,7 @@ jobs:
           fi
 
       - name: Increment Version
+        if: env.run_versioning == 'true'
         run: |
           IFS='.' read -r major minor patch <<< "$VERSION"
 
@@ -94,6 +99,7 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
       - name: Commit Updated Version (If Changed)
+        if: env.run_versioning == 'true'
         run: |
           git add CMakeLists.txt
           if git diff --staged --quiet; then
@@ -104,6 +110,7 @@ jobs:
           fi
 
       - name: Delete Old Tag (If Exists)
+        if: env.run_versioning == 'true'
         run: |
           if git rev-parse "v$NEW_VERSION" >/dev/null 2>&1; then
             git push --delete origin "v$NEW_VERSION"
@@ -114,6 +121,7 @@ jobs:
           fi
 
       - name: Create and Push New Git Tag
+        if: env.run_versioning == 'true'
         run: |
           git tag "v$NEW_VERSION"
           git push origin "v$NEW_VERSION"

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,81 @@
+name: 🏷️ Auto Versioning
+
+on:
+  pull_request:
+    types:
+      - synchronize  # XXX Temporary to test the workflow
+      #- closed  # Runs when PR is merged
+
+jobs:
+  versioning:
+    #if: github.event.pull_request.merged == true  # Only run if PR is merged
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get PR Labels
+        id: labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            console.log("PR Labels:", labels);
+            return labels;
+
+      - name: Determine Version Increment
+        id: version_type
+        run: |
+          echo "::notice::PR Labels Found: ${{ steps.labels.outputs.result }}"
+          if echo "${{ steps.labels.outputs.result }}" | grep -q "version:major"; then
+            echo "increment=major" >> $GITHUB_ENV
+            echo "::notice::Version Increment: major"
+          elif echo "${{ steps.labels.outputs.result }}" | grep -q "version:minor"; then
+            echo "increment=minor" >> $GITHUB_ENV
+            echo "::notice::Version Increment: minor"
+          else
+            echo "increment=patch" >> $GITHUB_ENV
+            echo "::notice::Version Increment: patch"
+          fi
+
+      - name: Read and Increment Version
+        id: update_version
+        run: |
+          VERSION=$(sed -nE 's/project\(atta VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt)
+
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Failed to extract version from CMakeLists.txt"
+            exit 1
+          fi
+
+          echo "::notice::Current Version: $VERSION"
+
+          IFS='.' read -r major minor patch <<< "$VERSION"
+
+          case "$increment" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+
+          NEW_VERSION="$major.$minor.$patch"
+          echo "::notice::New Version: $NEW_VERSION"
+
+          sed -i -E "s/(project\(atta VERSION) [0-9]+\.[0-9]+\.[0-9]+/\1 $NEW_VERSION/" CMakeLists.txt
+          echo "version=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Commit and Push Updated Version
+        run: |
+          git add CMakeLists.txt
+          git commit --allow-empty -m "Chore: Bump version to ${{ env.version }}"
+          git push
+
+      - name: Create Git Tag
+        run: |
+          git tag "v${{ env.version }}"
+          git push origin "v${{ env.version }}"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -6,11 +6,6 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to run CI on"
-        required: false
-        default: main
 
 jobs:
   build:
@@ -27,8 +22,6 @@ jobs:
 
       - name: Checkout atta
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Configure
         run: |

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,5 +1,16 @@
-name: Web
-on: [push, pull_request, release]
+name: 🕸️ Web
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to run CI on"
+        required: false
+        default: main
 
 jobs:
   build:
@@ -9,17 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {
-          name: "Web Latest",
-          os: ubuntu-latest,
-          build_type: "Release"
-        }
+        - { name: "Web Latest", os: ubuntu-latest, build_type: "Release" }
 
     steps:
       - uses: mymindstorm/setup-emsdk@v13
 
       - name: Checkout atta
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Configure
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,16 @@
-name: Windows
-on: [push, pull_request, release]
+name: 🪟 Windows
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to run CI on"
+        required: false
+        default: main
 
 jobs:
   build:
@@ -9,15 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - {
-          name: "Windows Latest",
-          os: windows-latest,
-          build_type: "Release"
-        }
+        - { name: "Windows Latest", os: windows-latest, build_type: "Release" }
 
     steps:
       - name: Checkout atta
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,11 +6,6 @@ on:
       - main
   pull_request:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to run CI on"
-        required: false
-        default: main
 
 jobs:
   build:
@@ -25,8 +20,6 @@ jobs:
     steps:
       - name: Checkout atta
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Install dependencies
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(atta VERSION 0.4.0 LANGUAGES CXX C)
+project(atta VERSION 0.3.3 LANGUAGES CXX C)
 
 OPTION(ATTA_BUILD_TESTS
     "Set to ON to build also the test executables"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(atta VERSION 0.3.3 LANGUAGES CXX C)
+project(atta VERSION 0.3.2 LANGUAGES CXX C)
 
 OPTION(ATTA_BUILD_TESTS
     "Set to ON to build also the test executables"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(atta VERSION 0.3.2 LANGUAGES CXX C)
+project(atta VERSION 0.3.3 LANGUAGES CXX C)
 
 OPTION(ATTA_BUILD_TESTS
     "Set to ON to build also the test executables"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(atta VERSION 0.3.3 LANGUAGES CXX C)
+project(atta VERSION 0.4.0 LANGUAGES CXX C)
 
 OPTION(ATTA_BUILD_TESTS
     "Set to ON to build also the test executables"


### PR DESCRIPTION
# Automate versioning with GitHub actions
<p align="center">
<img src="https://github.com/user-attachments/assets/a63766b1-3daf-4d28-a9b9-724ad435e06b" height="400"/>
</p>

This PR introduces a **GitHub Actions workflow** to automate versioning based on PR labels. It ensures that versioning is handled consistently by automatically updating the version in `CMakeLists.txt`, committing the change, and tagging the new version in Git. 

## 🔍 How It Works  

When you're ready to merge a PR, you **add a versioning label** (`version:major`, `version:minor`, or `version:patch`).  
This **triggers the workflow**, which will:  

1. **Merge `dev` into the PR branch** to ensure the latest version is used.  
   - If there are merge conflicts, the workflow **fails** and requires manual resolution.  

2. **Determine the new version** based on the label:  
   - `version:major` → `1.2.3 → 2.0.0`  
   - `version:minor` → `1.2.3 → 1.3.0`  
   - `version:patch` (default) → `1.2.3 → 1.2.4`  

3. **Update `CMakeLists.txt`** with the new version and create a commit (if necessary).

4. **Create and push a new Git tag**, linking it to the latest commit.  
   - The **PR title is used as the tag description** for better traceability.  

Once the workflow **completes**, the PR can be **merged into `dev`**, and the **new version is tagged automatically**.

## 🔧 Changelog
- **Feat**
  - Add workflow dispatch trigger to Linux, MacOS, Web, and Windows workflows
  - Add auto versioning workflow
- **Style**
  - Use concise matrix configuration in Linux, MacOS, Web, and Windows workflows
- **Chore**
  - Update workflow names with emojis for better visual distinction
  - Update `actions/checkout` to version 4
