### PR TITLE
Fix Bullet3 compilation error with CMake 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(atta VERSION 0.3.7 LANGUAGES CXX C)
+project(atta VERSION 0.3.8 LANGUAGES CXX C)
 
 option(ATTA_BUILD_TESTS "Set to ON to build also the test executables" ON)
 option(ATTA_BUILD_DOCS "Build the documentation" OFF)

--- a/src/extern/solveBullet.cmake
+++ b/src/extern/solveBullet.cmake
@@ -1,38 +1,32 @@
 set(ATTA_BULLET_SUPPORT FALSE)
 set(ATTA_BULLET_TARGETS "")
 
-#if(Bullet_FOUND)
-#    set(ATTA_BULLET_TARGETS ${BULLET_LIBRARIES})
-#    atta_add_include_dirs(${BULLET_INCLUDE_DIR})
-#
-#    atta_log(Success Extern "Bullet support (installed)")
-#    set(ATTA_BULLET_SUPPORT TRUE)
-#else()
-    set(USE_GRAPHICAL_BENCHMARK OFF CACHE INTERNAL "" FORCE)
-    set(BUILD_UNIT_TESTS OFF CACHE INTERNAL "" FORCE)
-    set(BUILD_BULLET3 ON CACHE INTERNAL "" FORCE)
-    set(BUILD_OBJ2SDF_EXTRA OFF CACHE INTERNAL "" FORCE)
-    set(BUILD_BULLET2_DEMOS OFF CACHE INTERNAL "" FORCE)
-    set(BUILD_CPU_DEMOS OFF CACHE INTERNAL "" FORCE)
-    set(BUILD_EXTRAS OFF CACHE INTERNAL "" FORCE)
-    set(INSTALL_LIBS OFF CACHE INTERNAL "" FORCE)
-    set(INSTALL_CMAKE_FILES OFF CACHE INTERNAL "" FORCE)
+set(USE_GRAPHICAL_BENCHMARK OFF CACHE INTERNAL "" FORCE)
+set(BUILD_UNIT_TESTS OFF CACHE INTERNAL "" FORCE)
+set(BUILD_BULLET3 ON CACHE INTERNAL "" FORCE)
+set(BUILD_OBJ2SDF_EXTRA OFF CACHE INTERNAL "" FORCE)
+set(BUILD_BULLET2_DEMOS OFF CACHE INTERNAL "" FORCE)
+set(BUILD_CPU_DEMOS OFF CACHE INTERNAL "" FORCE)
+set(BUILD_EXTRAS OFF CACHE INTERNAL "" FORCE)
+set(INSTALL_LIBS OFF CACHE INTERNAL "" FORCE)
+set(INSTALL_CMAKE_FILES OFF CACHE INTERNAL "" FORCE)
 
-    FetchContent_Declare(
-        bullet3
-        URL "http://storage.googleapis.com/atta-deps/bullet3-3.24-light.zip"
-    )
-    atta_log(Info Extern "Fetching Bullet...")
-    FetchContent_MakeAvailable(bullet3)
+FetchContent_Declare(
+    bullet3
+    GIT_REPOSITORY "https://github.com/brenocq/bullet3"
+    GIT_TAG "46acafe809976f867d5e295b0d5abd001952c607"
+    GIT_PROGRESS TRUE
+)
+atta_log(Info Extern "Fetching Bullet...")
+FetchContent_MakeAvailable(bullet3)
 
-    atta_add_include_dirs(
-        $<BUILD_INTERFACE:${FETCHCONTENT_BASE_DIR}/bullet3-src/src>
-        $<INSTALL_INTERFACE:include/${ATTA_VERSION_SAFE}/extern/bullet3/src>
-    )
+atta_add_include_dirs(
+    $<BUILD_INTERFACE:${FETCHCONTENT_BASE_DIR}/bullet3-src/src>
+    $<INSTALL_INTERFACE:include/${ATTA_VERSION_SAFE}/extern/bullet3/src>
+)
 
-    set(ATTA_BULLET_TARGETS "BulletDynamics;BulletCollision;LinearMath")
-    atta_add_libs(${ATTA_BULLET_TARGETS})
+set(ATTA_BULLET_TARGETS "BulletDynamics;BulletCollision;LinearMath")
+atta_add_libs(${ATTA_BULLET_TARGETS})
 
-    atta_log(Success Extern "Bullet support (source)")
-    set(ATTA_BULLET_SUPPORT TRUE)
-#endif()
+atta_log(Success Extern "Bullet support (source)")
+set(ATTA_BULLET_SUPPORT TRUE)


### PR DESCRIPTION
Bullet3 was not compiling for `CMake > 3.27`. This problem was fixed in https://github.com/bulletphysics/bullet3/pull/4704. I'll be using my bullet3 fork while that PR is not merged.