### PR TITLE
Transformation fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,7 @@ if(NOT (ATTA_SYSTEM_NAME MATCHES "Web") AND NOT ATTA_STATIC_PROJECT_FILE)
     # Write cmake targets
     install(EXPORT atta_targets
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ATTA_VERSION_SAFE}
+        NAMESPACE atta::
         FILE attaTargets.cmake
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(atta VERSION 0.3.8 LANGUAGES CXX C)
+project(atta VERSION 0.3.9 LANGUAGES CXX C)
 
 option(ATTA_BUILD_TESTS "Set to ON to build also the test executables" ON)
 option(ATTA_BUILD_DOCS "Build the documentation" OFF)

--- a/src/atta/atta.cpp
+++ b/src/atta/atta.cpp
@@ -68,10 +68,8 @@ Atta::Atta(const CreateInfo& info) : _shouldFinish(false) {
         LOG_WARN("Atta", "Project [w]$0[] will not be open because atta was built statically linked to [w]$1[]", info.projectFile, projectFile);
 #else
     // If a project was defined as argument, open project
-    if (!info.projectFile.empty()) {
-        graphics::update(); // Need to update to register the viewports
+    if (!info.projectFile.empty())
         file::openProject(info.projectFile);
-    }
 #endif
 
     _currStep = _lastStep = std::clock();

--- a/src/atta/component/components/boxCollider.cpp
+++ b/src/atta/component/components/boxCollider.cpp
@@ -11,8 +11,8 @@ namespace atta::component {
 template <>
 ComponentDescription& TypedComponentRegistry<BoxCollider>::getDescription() {
     static ComponentDescription desc = {"Box Collider",
-                                        {{AttributeType::FLOAT32, offsetof(BoxCollider, size), "size", 0.0001f, 2000.0f, 0.01f},
-                                         {AttributeType::FLOAT32, offsetof(BoxCollider, offset), "offset", -2000.0f, 2000.0f, 0.01f}}};
+                                        {{AttributeType::VECTOR_FLOAT32, offsetof(BoxCollider, size), "size", 0.0001f, 2000.0f, 0.01f},
+                                         {AttributeType::VECTOR_FLOAT32, offsetof(BoxCollider, offset), "offset", -2000.0f, 2000.0f, 0.01f}}};
 
     return desc;
 }

--- a/src/atta/component/components/boxCollider2D.cpp
+++ b/src/atta/component/components/boxCollider2D.cpp
@@ -13,8 +13,8 @@ ComponentDescription& TypedComponentRegistry<BoxCollider2D>::getDescription() {
     static ComponentDescription desc = {
         "Box Collider 2D",
         {
-            {AttributeType::FLOAT32, offsetof(BoxCollider2D, size), "size", 0.0001f, 2000.0f, 0.01f},
-            {AttributeType::FLOAT32, offsetof(BoxCollider2D, offset), "offset", -2000.0f, 2000.0f, 0.01f},
+            {AttributeType::VECTOR_FLOAT32, offsetof(BoxCollider2D, size), "size", 0.0001f, 2000.0f, 0.01f},
+            {AttributeType::VECTOR_FLOAT32, offsetof(BoxCollider2D, offset), "offset", -2000.0f, 2000.0f, 0.01f},
         },
     };
 

--- a/src/atta/component/components/circleCollider2D.cpp
+++ b/src/atta/component/components/circleCollider2D.cpp
@@ -15,7 +15,7 @@ ComponentDescription& TypedComponentRegistry<CircleCollider2D>::getDescription()
         "Circle Collider 2D",
         {
             {AttributeType::FLOAT32, offsetof(CircleCollider2D, radius), "radius", 0.0001f, 2000.0f, 0.01f},
-            {AttributeType::FLOAT32, offsetof(CircleCollider2D, offset), "offset", -2000.0f, 2000.0f, 0.01f},
+            {AttributeType::VECTOR_FLOAT32, offsetof(CircleCollider2D, offset), "offset", -2000.0f, 2000.0f, 0.01f},
         },
     };
 

--- a/src/atta/component/components/cylinderCollider.cpp
+++ b/src/atta/component/components/cylinderCollider.cpp
@@ -15,7 +15,7 @@ ComponentDescription& TypedComponentRegistry<CylinderCollider>::getDescription()
         {
             {AttributeType::FLOAT32, offsetof(CylinderCollider, radius), "radius", 0.0001f, 2000.0f, 0.01f},
             {AttributeType::FLOAT32, offsetof(CylinderCollider, height), "height", 0.0001f, 2000.0f, 0.01f},
-            {AttributeType::FLOAT32, offsetof(CylinderCollider, offset), "offset", -2000.0f, 2000.0f, 0.01f},
+            {AttributeType::VECTOR_FLOAT32, offsetof(CylinderCollider, offset), "offset", -2000.0f, 2000.0f, 0.01f},
         },
     };
 

--- a/src/atta/component/components/rigidBody.cpp
+++ b/src/atta/component/components/rigidBody.cpp
@@ -29,24 +29,6 @@ ComponentDescription& TypedComponentRegistry<RigidBody>::getDescription() {
     return desc;
 }
 
-void RigidBody::setLinearVelocity(vec3 vel) {
-    if (phy::getEngineType() == phy::Engine::BULLET) {
-        std::shared_ptr<phy::BulletEngine> bEngine = std::static_pointer_cast<phy::BulletEngine>(phy::getEngine());
-        bEngine->setLinearVelocity(this, vel);
-    } else {
-        LOG_WARN("cmp::RigidBody", "Could not execute [w]setLinearVelocity[], BULLET is not the current physics engine");
-    }
-}
-
-void RigidBody::setAngularVelocity(vec3 omega) {
-    if (phy::getEngineType() == phy::Engine::BULLET) {
-        std::shared_ptr<phy::BulletEngine> bEngine = std::static_pointer_cast<phy::BulletEngine>(phy::getEngine());
-        bEngine->setAngularVelocity(this, omega);
-    } else {
-        LOG_WARN("cmp::RigidBody", "Could not execute [w]setAngularVelocity[], BULLET is not the current physics engine");
-    }
-}
-
 void RigidBody::applyForce(vec3 force, vec3 point) {
     if (phy::getEngineType() == phy::Engine::BULLET) {
         std::shared_ptr<phy::BulletEngine> bEngine = std::static_pointer_cast<phy::BulletEngine>(phy::getEngine());

--- a/src/atta/component/components/rigidBody.cpp
+++ b/src/atta/component/components/rigidBody.cpp
@@ -5,6 +5,8 @@
 // By Breno Cunha Queiroz
 //--------------------------------------------------
 #include <atta/component/components/rigidBody.h>
+#include <atta/physics/engines/bulletEngine.h>
+#include <atta/physics/interface.h>
 
 namespace atta::component {
 template <>
@@ -23,6 +25,51 @@ ComponentDescription& TypedComponentRegistry<RigidBody>::getDescription() {
                                          {AttributeType::UINT8, offsetof(RigidBody, constraints), "constraints"}}};
 
     return desc;
+}
+
+void RigidBody::setLinearVelocity(vec3 vel) {
+    if (phy::getEngineType() == phy::Engine::BULLET) {
+        std::shared_ptr<phy::BulletEngine> bEngine = std::static_pointer_cast<phy::BulletEngine>(phy::getEngine());
+        bEngine->setLinearVelocity(this, vel);
+    } else {
+        LOG_WARN("cmp::RigidBody", "Could not execute [w]setLinearVelocity[], BULLET is not the current physics engine");
+    }
+}
+
+void RigidBody::setAngularVelocity(vec3 omega) {
+    if (phy::getEngineType() == phy::Engine::BULLET) {
+        std::shared_ptr<phy::BulletEngine> bEngine = std::static_pointer_cast<phy::BulletEngine>(phy::getEngine());
+        bEngine->setAngularVelocity(this, omega);
+    } else {
+        LOG_WARN("cmp::RigidBody", "Could not execute [w]setAngularVelocity[], BULLET is not the current physics engine");
+    }
+}
+
+void RigidBody::applyForce(vec3 force, vec3 point) {
+    if (phy::getEngineType() == phy::Engine::BULLET) {
+        std::shared_ptr<phy::BulletEngine> bEngine = std::static_pointer_cast<phy::BulletEngine>(phy::getEngine());
+        bEngine->applyForce(this, force, point);
+    } else {
+        LOG_WARN("cmp::RigidBody", "Could not execute [w]applyForce[], BULLET is not the current physics engine");
+    }
+}
+
+void RigidBody::applyForceToCenter(vec3 force) {
+    if (phy::getEngineType() == phy::Engine::BULLET) {
+        std::shared_ptr<phy::BulletEngine> bEngine = std::static_pointer_cast<phy::BulletEngine>(phy::getEngine());
+        bEngine->applyForceToCenter(this, force);
+    } else {
+        LOG_WARN("cmp::RigidBody", "Could not execute [w]applyForceToCenter[], BULLET is not the current physics engine");
+    }
+}
+
+void RigidBody::applyTorque(vec3 torque) {
+    if (phy::getEngineType() == phy::Engine::BULLET) {
+        std::shared_ptr<phy::BulletEngine> bEngine = std::static_pointer_cast<phy::BulletEngine>(phy::getEngine());
+        bEngine->applyTorque(this, torque);
+    } else {
+        LOG_WARN("cmp::RigidBody", "Could not execute [w]applyTorque[], BULLET is not the current physics engine");
+    }
 }
 
 } // namespace atta::component

--- a/src/atta/component/components/rigidBody.cpp
+++ b/src/atta/component/components/rigidBody.cpp
@@ -11,18 +11,20 @@
 namespace atta::component {
 template <>
 ComponentDescription& TypedComponentRegistry<RigidBody>::getDescription() {
-    static ComponentDescription desc = {"Rigid Body",
-                                        {{AttributeType::UINT32, offsetof(RigidBody, type), "type", {}, {}, {}, {"DYNAMIC", "KINEMATIC", "STATIC"}},
-                                         {AttributeType::VECTOR_FLOAT32, offsetof(RigidBody, linearVelocity), "linearVelocity", {}, {}, 0.001f},
-                                         {AttributeType::VECTOR_FLOAT32, offsetof(RigidBody, angularVelocity), "angularVelocity", {}, {}, 0.001f},
-                                         {AttributeType::FLOAT32, offsetof(RigidBody, mass), "mass", 0.0f, 100.0f, 0.001f},
-                                         {AttributeType::FLOAT32, offsetof(RigidBody, friction), "friction", 0.0f, 1.0f, 0.001f},
-                                         {AttributeType::FLOAT32, offsetof(RigidBody, restitution), "restitution", 0.0f, 1.0f, 0.001f},
-                                         {AttributeType::FLOAT32, offsetof(RigidBody, linearDamping), "linearDamping", {}, {}, 0.001f},
-                                         {AttributeType::FLOAT32, offsetof(RigidBody, angularDamping), "angularDamping", {}, {}, 0.001f},
-                                         {AttributeType::BOOL, offsetof(RigidBody, allowSleep), "allowSleep"},
-                                         {AttributeType::BOOL, offsetof(RigidBody, awake), "awake"},
-                                         {AttributeType::UINT8, offsetof(RigidBody, constraints), "constraints"}}};
+    static ComponentDescription desc = {
+        "Rigid Body",
+        {
+            {AttributeType::UINT32, offsetof(RigidBody, type), "type", {}, {}, {}, {"DYNAMIC", "KINEMATIC", "STATIC"}},
+            {AttributeType::VECTOR_FLOAT32, offsetof(RigidBody, linearVelocity), "linearVelocity", {}, {}, 0.001f},
+            {AttributeType::VECTOR_FLOAT32, offsetof(RigidBody, angularVelocity), "angularVelocity", {}, {}, 0.001f},
+            {AttributeType::FLOAT32, offsetof(RigidBody, mass), "mass", 0.0f, 100.0f, 0.001f},
+            {AttributeType::FLOAT32, offsetof(RigidBody, friction), "friction", 0.0f, 1.0f, 0.001f},
+            {AttributeType::FLOAT32, offsetof(RigidBody, restitution), "restitution", 0.0f, 1.0f, 0.001f},
+            {AttributeType::FLOAT32, offsetof(RigidBody, linearDamping), "linearDamping", {}, {}, 0.001f},
+            {AttributeType::FLOAT32, offsetof(RigidBody, angularDamping), "angularDamping", {}, {}, 0.001f},
+            {AttributeType::BOOL, offsetof(RigidBody, allowSleep), "allowSleep"},
+            {AttributeType::BOOL, offsetof(RigidBody, awake), "awake"},
+        }};
 
     return desc;
 }

--- a/src/atta/component/components/rigidBody.cpp
+++ b/src/atta/component/components/rigidBody.cpp
@@ -56,4 +56,14 @@ void RigidBody::applyTorque(vec3 torque) {
     }
 }
 
+mat3 RigidBody::getInertiaTensor() {
+    if (phy::getEngineType() == phy::Engine::BULLET) {
+        std::shared_ptr<phy::BulletEngine> bEngine = std::static_pointer_cast<phy::BulletEngine>(phy::getEngine());
+        return bEngine->getInertiaTensor(this);
+    } else {
+        LOG_WARN("cmp::RigidBody", "Could not execute [w]getInertiaTensor[], BULLET is not the current physics engine");
+        return mat3(1.0f);
+    }
+}
+
 } // namespace atta::component

--- a/src/atta/component/components/rigidBody.cpp
+++ b/src/atta/component/components/rigidBody.cpp
@@ -11,8 +11,8 @@ template <>
 ComponentDescription& TypedComponentRegistry<RigidBody>::getDescription() {
     static ComponentDescription desc = {"Rigid Body",
                                         {{AttributeType::UINT32, offsetof(RigidBody, type), "type", {}, {}, {}, {"DYNAMIC", "KINEMATIC", "STATIC"}},
-                                         {AttributeType::FLOAT32, offsetof(RigidBody, linearVelocity), "linearVelocity", {}, {}, 0.001f},
-                                         {AttributeType::FLOAT32, offsetof(RigidBody, angularVelocity), "angularVelocity", {}, {}, 0.001f},
+                                         {AttributeType::VECTOR_FLOAT32, offsetof(RigidBody, linearVelocity), "linearVelocity", {}, {}, 0.001f},
+                                         {AttributeType::VECTOR_FLOAT32, offsetof(RigidBody, angularVelocity), "angularVelocity", {}, {}, 0.001f},
                                          {AttributeType::FLOAT32, offsetof(RigidBody, mass), "mass", 0.0f, 100.0f, 0.001f},
                                          {AttributeType::FLOAT32, offsetof(RigidBody, friction), "friction", 0.0f, 1.0f, 0.001f},
                                          {AttributeType::FLOAT32, offsetof(RigidBody, restitution), "restitution", 0.0f, 1.0f, 0.001f},

--- a/src/atta/component/components/rigidBody.h
+++ b/src/atta/component/components/rigidBody.h
@@ -30,15 +30,6 @@ struct RigidBody final : public Component {
      */
     enum Type : uint32_t { DYNAMIC = 0, KINEMATIC, STATIC };
 
-    enum Constraint {
-        FREEZE_ORIENTATION_X = (1 << 0),
-        FREEZE_ORIENTATION_Y = (1 << 1),
-        FREEZE_ORIENTATION_Z = (1 << 2),
-        FREEZE_POSITION_X = (1 << 3),
-        FREEZE_POSITION_Y = (1 << 4),
-        FREEZE_POSITION_Z = (1 << 5),
-    };
-
     Type type = DYNAMIC;
     // Rigid body state
     vec3 linearVelocity = {0.0f, 0.0f, 0.0f};  ///< Linear velocity
@@ -63,8 +54,6 @@ struct RigidBody final : public Component {
      */
     bool allowSleep = true; ///< If the rigid body can sleep
     bool awake = true;      ///< If the rigid body start awake or sleeping
-                            /** Use RigidBody::Constraint to specify the contraints */
-    uint8_t constraints;    ///< Rigid body constraints
 
     /// Set linear velocity
     /// @param vel velocity in meters/second

--- a/src/atta/component/components/rigidBody.h
+++ b/src/atta/component/components/rigidBody.h
@@ -65,6 +65,28 @@ struct RigidBody final : public Component {
     bool awake = true;      ///< If the rigid body start awake or sleeping
                             /** Use RigidBody::Constraint to specify the contraints */
     uint8_t constraints;    ///< Rigid body constraints
+
+    /// Set linear velocity
+    /// @param vel velocity in meters/second
+    void setLinearVelocity(vec3 vel);
+    /// Set angular velocity
+    /// @param omega velocity in radians/second
+    void setAngularVelocity(vec3 omega);
+
+    /// Apply a force at a world point. If the force is not applied at the center of mass,
+    /// it will generate a torque and affect the angular velocity.
+    /// @param force the world force vector in Newtons (N).
+    /// @param point the world position of the point of application.
+    void applyForce(vec3 force, vec3 point);
+
+    /// Apply a force to the body's center of mass.
+    /// @param force the world force vector in Newtons (N).
+    void applyForceToCenter(vec3 force);
+
+    /// Apply a torque. This affects the angular velocity without affecting
+    /// the linear velocity of the center of mass.
+    /// @param torque about the z-axis (out of the screen), usually in N-m.
+    void applyTorque(vec3 torque);
 };
 ATTA_REGISTER_COMPONENT(RigidBody)
 template <>

--- a/src/atta/component/components/rigidBody.h
+++ b/src/atta/component/components/rigidBody.h
@@ -32,8 +32,8 @@ struct RigidBody final : public Component {
 
     Type type = DYNAMIC;
     // Rigid body state
-    vec3 linearVelocity = {0.0f, 0.0f, 0.0f};  ///< Linear velocity
-    vec3 angularVelocity = {0.0f, 0.0f, 0.0f}; ///< Angular velocity
+    vec3 linearVelocity = {0.0f, 0.0f, 0.0f};  ///< Linear velocity in world frame (m/s)
+    vec3 angularVelocity = {0.0f, 0.0f, 0.0f}; ///< Angular velocity in world frame (rad/s)
     // Material properties
     float mass = 1.0f;     ///< Physics material mass
     float friction = 0.5f; ///< Physics material friction coefficient

--- a/src/atta/component/components/rigidBody.h
+++ b/src/atta/component/components/rigidBody.h
@@ -55,13 +55,6 @@ struct RigidBody final : public Component {
     bool allowSleep = true; ///< If the rigid body can sleep
     bool awake = true;      ///< If the rigid body start awake or sleeping
 
-    /// Set linear velocity
-    /// @param vel velocity in meters/second
-    void setLinearVelocity(vec3 vel);
-    /// Set angular velocity
-    /// @param omega velocity in radians/second
-    void setAngularVelocity(vec3 omega);
-
     /// Apply a force at a world point. If the force is not applied at the center of mass,
     /// it will generate a torque and affect the angular velocity.
     /// @param force the world force vector in Newtons (N).

--- a/src/atta/component/components/rigidBody.h
+++ b/src/atta/component/components/rigidBody.h
@@ -69,6 +69,9 @@ struct RigidBody final : public Component {
     /// the linear velocity of the center of mass.
     /// @param torque about the z-axis (out of the screen), usually in N-m.
     void applyTorque(vec3 torque);
+
+    /// Get the inertia tensor of the rigid body in the world frame.
+    mat3 getInertiaTensor();
 };
 ATTA_REGISTER_COMPONENT(RigidBody)
 template <>

--- a/src/atta/component/components/rigidBody2D.cpp
+++ b/src/atta/component/components/rigidBody2D.cpp
@@ -16,7 +16,7 @@ ComponentDescription& TypedComponentRegistry<RigidBody2D>::getDescription() {
         "Rigid Body 2D",
         {
             {AttributeType::UINT32, offsetof(RigidBody2D, type), "type", {}, {}, {}, {"DYNAMIC", "KINEMATIC", "STATIC"}},
-            {AttributeType::FLOAT32, offsetof(RigidBody2D, linearVelocity), "linearVelocity", {}, {}, 0.001f},
+            {AttributeType::VECTOR_FLOAT32, offsetof(RigidBody2D, linearVelocity), "linearVelocity", {}, {}, 0.001f},
             {AttributeType::FLOAT32, offsetof(RigidBody2D, angularVelocity), "angularVelocity", {}, {}, 0.001f},
             {AttributeType::FLOAT32, offsetof(RigidBody2D, mass), "mass", 0.0f, 100.0f, 0.001f},
             {AttributeType::FLOAT32, offsetof(RigidBody2D, friction), "friction", 0.0f, 1.0f, 0.001f},

--- a/src/atta/component/components/sphereCollider.cpp
+++ b/src/atta/component/components/sphereCollider.cpp
@@ -15,7 +15,7 @@ ComponentDescription& TypedComponentRegistry<SphereCollider>::getDescription() {
         "Sphere Collider",
         {
             {AttributeType::FLOAT32, offsetof(SphereCollider, radius), "radius", 0.0001f, 2000.0f, 0.01f},
-            {AttributeType::FLOAT32, offsetof(SphereCollider, offset), "offset", -2000.0f, 2000.0f, 0.01f},
+            {AttributeType::VECTOR_FLOAT32, offsetof(SphereCollider, offset), "offset", -2000.0f, 2000.0f, 0.01f},
         },
     };
 

--- a/src/atta/component/components/transform.cpp
+++ b/src/atta/component/components/transform.cpp
@@ -68,10 +68,13 @@ Transform Transform::getEntityWorldTransform(EntityId entity) {
     auto t = component::getComponent<Transform>(curr);
     auto r = component::getComponent<Relationship>(curr);
 
+    // Go up the hierarchy until the first entity with transform component if found
     do {
+        // Return the world transform of the first entity with transform component
         if (t)
             return t->getWorldTransform(curr);
 
+        // Return default transform if no transform component is found
         curr = r->getParent();
         if (curr == -1)
             return Transform{};
@@ -91,9 +94,8 @@ Transform Transform::operator*(const Transform& o) const {
 
     // Calculate scale
     vec3 finalScale = o.scale;
-    o.orientation.rotateVector(finalScale);
-    finalScale *= scale;
-    world.scale = finalScale;
+    orientation.rotateVector(finalScale);
+    world.scale = scale * finalScale;
 
     // Calculate position
     vec3 finalPos = scale * o.position;

--- a/src/atta/component/components/transform.cpp
+++ b/src/atta/component/components/transform.cpp
@@ -88,39 +88,21 @@ Transform Transform::getEntityWorldTransform(EntityId entity) {
 Transform Transform::operator*(const Transform& o) const {
     // World = parent * local
     Transform world;
-
-    // Calculate orientation
+    world.position = position + orientation * (scale * o.position);
     world.orientation = orientation * o.orientation;
-
-    // Calculate scale
-    vec3 finalScale = o.scale;
-    orientation.rotateVector(finalScale);
-    world.scale = scale * finalScale;
-
-    // Calculate position
-    vec3 finalPos = scale * o.position;
-    orientation.rotateVector(finalPos);
-    world.position = position + finalPos;
+    world.scale = scale * o.scale;
 
     return world;
 }
 
 Transform Transform::operator/(const Transform& o) const {
     // Local = world / parent
-    Transform local;
-
     quat oriConj = inverse(o.orientation);
 
-    // Calculate orientation
+    Transform local;
+    local.position = oriConj * (position - o.position) / o.scale;
     local.orientation = oriConj * orientation;
-
-    // Calculate scale
     local.scale = scale / o.scale;
-    oriConj.rotateVector(local.scale);
-
-    // Calculate position
-    local.position = (position - o.position) / o.scale;
-    oriConj.rotateVector(local.position);
 
     return local;
 }

--- a/src/atta/component/components/transform.h
+++ b/src/atta/component/components/transform.h
@@ -30,7 +30,7 @@ struct Transform final : public Component {
 
     /// Get transform in the world coordinate system
     /** If the entity is child of another entity the
-     * resulting transform will depend on its parent 
+     * resulting transform will depend on its parent
      * world transform.
      *
      * The world transform will only differ from the local

--- a/src/atta/file/project/project.cpp
+++ b/src/atta/file/project/project.cpp
@@ -11,8 +11,7 @@ namespace atta::file {
 
 Project::Project(fs::path file) : _name(file.stem().string()), _file(fs::absolute(file)), _directory(file.parent_path()) {
     fs::path projectResourcePath = _directory / "resources";
-    if (fs::exists(projectResourcePath))
-        _resourceRootPaths.push_back(projectResourcePath);
+    _resourceRootPaths.push_back(projectResourcePath);
     _resourceRootPaths.push_back(fs::path(ATTA_DIR) / "resources");
 
     LOG_DEBUG("file::Project", "Opened project [*g]$0[] ([w]$1[])", _name, _file);

--- a/src/atta/physics/engines/bulletEngine.cpp
+++ b/src/atta/physics/engines/bulletEngine.cpp
@@ -29,9 +29,9 @@ BulletEngine::~BulletEngine() {
 
 //---------- Conversions ----------//
 inline btVector3 attaToBt(const vec3& vec) { return btVector3(vec.x, vec.y, vec.z); }
-inline btQuaternion attaToBt(const quat& q) { return btQuaternion(-q.i, -q.j, -q.k, q.r); }
+inline btQuaternion attaToBt(const quat& q) { return btQuaternion(q.i, q.j, q.k, q.r); }
 inline vec3 btToAtta(const btVector3& vec) { return vec3(vec.getX(), vec.getY(), vec.getZ()); }
-inline quat btToAtta(const btQuaternion& q) { return quat(q.getW(), -q.getX(), -q.getY(), -q.getZ()); }
+inline quat btToAtta(const btQuaternion& q) { return quat(q.getW(), q.getX(), q.getY(), q.getZ()); }
 
 //----------------------------------------------//
 //------------------- START --------------------//
@@ -81,14 +81,11 @@ void BulletEngine::step(float dt) {
         auto rb = component::getComponent<component::RigidBody>(eid);
 
         // Wake up entity if it is not active
-        if (rb->awake && !body->isActive()) {
-            LOG_INFO("BulletEngine", "Updating awake");
+        if (rb->awake && !body->isActive())
             wakeUpEntity(eid);
-        }
 
         // Update linear velocity
         if (rb->linearVelocity != btToAtta(body->getLinearVelocity())) {
-            LOG_INFO("BulletEngine", "Updating lin vel");
             body->setLinearVelocity(attaToBt(rb->linearVelocity));
             wakeUpEntity(eid);
         }
@@ -103,16 +100,13 @@ void BulletEngine::step(float dt) {
         if (rb->type == component::RigidBody::DYNAMIC) {
             // Update mass
             if (rb->mass != body->getMass()) {
-                LOG_INFO("BulletEngine", "Updating mass $0 to $1", rb->mass, body->getMass());
                 body->setMassProps(rb->mass, body->getLocalInertia());
                 rb->mass = body->getMass(); // Bullet's internal mass may be slightly different
             }
 
             // Update linear/angular damping
-            if (rb->linearDamping != body->getLinearDamping() || rb->angularDamping != body->getAngularDamping()) {
-                LOG_INFO("BulletEngine", "Updating damping");
+            if (rb->linearDamping != body->getLinearDamping() || rb->angularDamping != body->getAngularDamping())
                 body->setDamping(rb->linearDamping, rb->angularDamping);
-            }
         }
 
         // Update transform (position/orientation)

--- a/src/atta/physics/engines/bulletEngine.cpp
+++ b/src/atta/physics/engines/bulletEngine.cpp
@@ -157,8 +157,8 @@ void BulletEngine::step(float dt) {
 
         // Update rigid body
         auto rb = component::getComponent<component::RigidBody>(eid);
-        btVector3 linearVelocity = body->getLinearVelocity();
-        btVector3 angularVelocity = body->getAngularVelocity();
+        rb->linearVelocity = btToAtta(body->getLinearVelocity());
+        rb->angularVelocity = btToAtta(body->getAngularVelocity());
     }
 
     //----- Update atta joints -----//

--- a/src/atta/physics/engines/bulletEngine.h
+++ b/src/atta/physics/engines/bulletEngine.h
@@ -32,11 +32,10 @@ class BulletEngine : public Engine {
     void updateGravity() override;
 
     // component::RigidBody interface
-    void setLinearVelocity(component::RigidBody* rb, vec3 vel);
-    void setAngularVelocity(component::RigidBody* rb, vec3 omega);
     void applyForce(component::RigidBody* rb, vec3 force, vec3 point);
     void applyForceToCenter(component::RigidBody* rb, vec3 force);
     void applyTorque(component::RigidBody* rb, vec3 torque);
+    mat3 getInertiaTensor(component::RigidBody* rb);
 
     unsigned getNumSubSteps() const;
     void setNumSubSteps(unsigned numSubSteps);

--- a/src/atta/physics/engines/bulletEngine.h
+++ b/src/atta/physics/engines/bulletEngine.h
@@ -10,6 +10,7 @@
 #include "btBulletDynamicsCommon.h"
 #include <atta/component/components/prismaticJoint.h>
 #include <atta/component/components/revoluteJoint.h>
+#include <atta/component/components/rigidBody.h>
 #include <atta/component/components/rigidJoint.h>
 #include <atta/physics/engines/engine.h>
 
@@ -29,6 +30,13 @@ class BulletEngine : public Engine {
     bool areColliding(component::EntityId eid0, component::EntityId eid1) override;
 
     void updateGravity() override;
+
+    // component::RigidBody interface
+    void setLinearVelocity(component::RigidBody* rb, vec3 vel);
+    void setAngularVelocity(component::RigidBody* rb, vec3 omega);
+    void applyForce(component::RigidBody* rb, vec3 force, vec3 point);
+    void applyForceToCenter(component::RigidBody* rb, vec3 force);
+    void applyTorque(component::RigidBody* rb, vec3 torque);
 
     unsigned getNumSubSteps() const;
     void setNumSubSteps(unsigned numSubSteps);
@@ -60,6 +68,7 @@ class BulletEngine : public Engine {
     // World data
     std::unordered_map<component::EntityId, btRigidBody*> _entityToBody;
     std::unordered_map<btRigidBody*, component::EntityId> _bodyToEntity;
+    std::unordered_map<component::RigidBody*, component::EntityId> _componentToEntity;
     std::unordered_map<component::EntityId, std::unordered_map<component::EntityId, btPersistentManifold*>> _collisions;
     std::unordered_map<component::EntityId, std::vector<component::EntityId>> _connectedEntities; ///< Which entities are connect by joints
 

--- a/src/atta/physics/engines/bulletEngine.h
+++ b/src/atta/physics/engines/bulletEngine.h
@@ -55,6 +55,8 @@ class BulletEngine : public Engine {
     static void collisionStarted(btPersistentManifold* const& manifold);
     static void collisionEnded(btPersistentManifold* const& manifold);
 
+    void wakeUpEntity(component::EntityId entity);
+
     unsigned _numSubSteps; ///< Number of physics sub steps for each simulation step
 
     // World configutation

--- a/src/atta/physics/manager.cpp
+++ b/src/atta/physics/manager.cpp
@@ -126,6 +126,7 @@ void Manager::onComponentChange(event::Event& event) {
                     _engine->createColliders(e.entityId);
             }
             if (is3DPhysicsColliderComponent(e.componentId)) {
+                // TODO
             }
             break;
         }
@@ -138,6 +139,7 @@ void Manager::onComponentChange(event::Event& event) {
                     _engine->deleteColliders(e.entityId);
             }
             if (is3DPhysicsColliderComponent(e.componentId)) {
+                // TODO
             }
             break;
         }

--- a/src/atta/resource/manager.cpp
+++ b/src/atta/resource/manager.cpp
@@ -64,6 +64,9 @@ void Manager::loadResourcesRecursively(fs::path directory) {
     static const std::vector<std::string> meshExtensions{".obj", ".fbx", ".FBX", ".fbx", ".stl", ".ply"};
     static const std::vector<std::string> imageExtensions{".jpg", ".jpeg", ".png", ".hdr", ".tga"};
 
+    if (!fs::exists(directory))
+        return;
+
     for (auto file : file::getDirectoryFilesRecursive(directory)) {
         // Load as mesh
         for (auto& extension : meshExtensions)

--- a/src/atta/ui/widgets/gizmo.cpp
+++ b/src/atta/ui/widgets/gizmo.cpp
@@ -63,60 +63,10 @@ bool Gizmo::manipulate(cmp::EntityId entity) {
         if (ImGuizmo::IsUsing()) {
             transform.transpose();
 
-            // Get changed
-            vec3 pos, scale;
-            quat newOri;
-            transform.getPosOriScale(pos, newOri, scale);
-            vec3 oriDelta = newOri.getEuler() - t->orientation.getEuler();
-            quat ori;
-            ori.setEuler(t->orientation.getEuler() + oriDelta);
-
-            // Delta world to local
-            cmp::Relationship* r = cmp::getComponent<cmp::Relationship>(entity);
-            if (r && r->getParent() != -1) {
-                // Get transform of the first entity that has transform when going up in the hierarchy
-                cmp::Transform* pt = nullptr;
-                cmp::EntityId parentId = -1;
-                while (pt == nullptr) {
-                    parentId = r->getParent();
-                    pt = cmp::getComponent<cmp::Transform>(parentId);
-                    r = cmp::getComponent<cmp::Relationship>(parentId);
-                    if (r->getParent() == -1)
-                        break;
-                }
-
-                // If found some entity with transform component, convert result to be relative to it
-                if (pt) {
-                    cmp::Transform pTransform = pt->getWorldTransform(parentId);
-                    vec3 pPos = pTransform.position;
-                    vec3 pScale = pTransform.scale;
-                    quat pOri = pTransform.orientation;
-
-                    // Calculate pos ori scale relative to parent
-                    pos -= pPos;
-                    scale /= pScale;
-                    ori = ori * (-pOri); // Rotation from pOri to ori
-                }
-            }
-
-            // Update entity transform
-            if (operation == ImGuizmo::OPERATION::TRANSLATE)
-                t->position = pos;
-            else if (operation == ImGuizmo::OPERATION::ROTATE)
-                t->orientation = ori;
-            else if (operation == ImGuizmo::OPERATION::SCALE)
-                t->scale = scale;
-
-            // cmp::RigidBody2D* rb2d = cmp::getComponent<cmp::RigidBody2D>(entity);
-            // if (rb2d) {
-            //     if (mouseOperation == ImGuizmo::OPERATION::TRANSLATE || mouseOperation == ImGuizmo::OPERATION::ROTATE) {
-            //         vec2 pos = vec2(t->position);
-            //         float angle = -t->orientation.getEuler().z;
-            //         rb2d->setTransform(pos, angle);
-            //     } else if (mouseOperation == ImGuizmo::OPERATION::SCALE) {
-            //         // TODO Recreate box2d rigid body
-            //     }
-            // }
+            // Set new world transform
+            cmp::Transform newT;
+            transform.getPosOriScale(newT.position, newT.orientation, newT.scale);
+            t->setWorldTransform(entity, newT);
             return true;
         }
     }

--- a/src/atta/utils/CMakeLists.txt
+++ b/src/atta/utils/CMakeLists.txt
@@ -43,3 +43,8 @@ atta_create_local_test(
     "tests/math.cpp"
     "atta_utils"
 )
+atta_create_local_test(
+    atta_utils_quaternion_test
+    "tests/quaternion.cpp"
+    "atta_utils"
+)

--- a/src/atta/utils/CMakeLists.txt
+++ b/src/atta/utils/CMakeLists.txt
@@ -44,6 +44,11 @@ atta_create_local_test(
     "atta_utils"
 )
 atta_create_local_test(
+    atta_utils_matrix_test
+    "tests/matrix.cpp"
+    "atta_utils"
+)
+atta_create_local_test(
     atta_utils_quaternion_test
     "tests/quaternion.cpp"
     "atta_utils"

--- a/src/atta/utils/math/common.cpp
+++ b/src/atta/utils/math/common.cpp
@@ -7,11 +7,26 @@
 #include <atta/utils/math/common.h>
 
 namespace atta {
+
 float radians(float degrees) { return degrees * 0.01745329251f; }
-
 vec3 radians(vec3 vec) { return vec * 0.01745329251f; }
-
 float degrees(float radians) { return radians * 57.2957795147f; }
-
 vec3 degrees(vec3 vec) { return vec * 57.2957795147f; }
+
+float wrapRadians(float angle) {
+    while (angle > M_PI)
+        angle -= 2.0f * M_PI;
+    while (angle < -M_PI)
+        angle += 2.0f * M_PI;
+    return angle;
+}
+
+float wrapDegrees(float angle) {
+    while (angle > 180.0f)
+        angle -= 360.0f;
+    while (angle < -180.0f)
+        angle += 360.0f;
+    return angle;
+}
+
 } // namespace atta

--- a/src/atta/utils/math/common.h
+++ b/src/atta/utils/math/common.h
@@ -15,6 +15,11 @@ vec3 radians(vec3 vec);
 float degrees(float radians);
 vec3 degrees(vec3 vec);
 
+// Wraps the angle in radians to the range [-PI, PI]
+float wrapRadians(float angle);
+// Wraps the angle in degrees to the range [-180, 180]
+float wrapDegrees(float angle);
+
 static constexpr float maxFloat = std::numeric_limits<float>::max();
 static constexpr float infinity = std::numeric_limits<float>::infinity();
 static constexpr float machineEpsilon = std::numeric_limits<float>::epsilon() * 0.5;

--- a/src/atta/utils/math/matrix.cpp
+++ b/src/atta/utils/math/matrix.cpp
@@ -339,44 +339,25 @@ vec3 mat4::transformInverse(const vec3& vector) const {
 // Gets a vector representing one axis (one column) in the matrix.
 vec3 mat4::getAxisVector(int i) const { return vec3(data[i], data[i + 4], data[i + 8]); }
 
-// Sets this matrix to be the rotation matrix corresponding to
-// the given quaternion.
 void mat4::setPosOri(const vec3& pos, const quat& q) {
-    mat[0][0] = 1 - (2 * q.j * q.j + 2 * q.k * q.k);
-    mat[0][1] = 2 * q.i * q.j - 2 * q.k * q.r;
-    mat[0][2] = 2 * q.i * q.k + 2 * q.j * q.r;
-    mat[0][3] = pos.x;
+    // Obtain the 3x3 rotation matrix from the quaternion
+    mat3 R = q.getRotationMatrix();
 
-    mat[1][0] = 2 * q.i * q.j + 2 * q.k * q.r;
-    mat[1][1] = 1 - (2 * q.i * q.i + 2 * q.k * q.k);
-    mat[1][2] = 2 * q.j * q.k - 2 * q.i * q.r;
-    mat[1][3] = pos.y;
-
-    mat[2][0] = 2 * q.i * q.k - 2 * q.j * q.r;
-    mat[2][1] = 2 * q.j * q.k + 2 * q.i * q.r;
-    mat[2][2] = 1 - (2 * q.i * q.i + 2 * q.j * q.j);
-    mat[2][3] = pos.z;
-
-    mat[3][0] = 0;
-    mat[3][1] = 0;
-    mat[3][2] = 0;
-    mat[3][3] = 1;
-}
-
-void mat4::setPosOriScale(const vec3& pos, const quat& q, const vec3& scale) {
-    data[0] = (1 - (2 * q.j * q.j + 2 * q.k * q.k)) * scale.x;
-    data[1] = (2 * q.i * q.j + 2 * q.k * q.r) * scale.y;
-    data[2] = (2 * q.i * q.k - 2 * q.j * q.r) * scale.z;
+    // Embed the rotation matrix into the 4x4 matrix
+    // Translation is placed in the fourth column
+    data[0] = R.data[0];
+    data[1] = R.data[1];
+    data[2] = R.data[2];
     data[3] = pos.x;
 
-    data[4] = (2 * q.i * q.j - 2 * q.k * q.r) * scale.x;
-    data[5] = (1 - (2 * q.i * q.i + 2 * q.k * q.k)) * scale.y;
-    data[6] = (2 * q.j * q.k + 2 * q.i * q.r) * scale.z;
+    data[4] = R.data[3];
+    data[5] = R.data[4];
+    data[6] = R.data[5];
     data[7] = pos.y;
 
-    data[8] = (2 * q.i * q.k + 2 * q.j * q.r) * scale.x;
-    data[9] = (2 * q.j * q.k - 2 * q.i * q.r) * scale.y;
-    data[10] = (1 - (2 * q.i * q.i + 2 * q.j * q.j)) * scale.z;
+    data[8] = R.data[6];
+    data[9] = R.data[7];
+    data[10] = R.data[8];
     data[11] = pos.z;
 
     data[12] = 0;
@@ -385,39 +366,77 @@ void mat4::setPosOriScale(const vec3& pos, const quat& q, const vec3& scale) {
     data[15] = 1;
 }
 
-vec3 mat4::getPosition() const {
-    vec3 pos;
-    pos.x = mat[0][3];
-    pos.y = mat[1][3];
-    pos.z = mat[2][3];
+void mat4::setPosOriScale(const vec3& pos, const quat& q, const vec3& scale) {
+    // Obtain the 3x3 rotation matrix from the quaternion
+    mat3 R = q.getRotationMatrix();
 
-    return pos;
+    // Apply scaling along each axis (scaling is applied per column of R)
+    data[0] = R.data[0] * scale.x;
+    data[1] = R.data[1] * scale.y;
+    data[2] = R.data[2] * scale.z;
+    data[3] = pos.x;
+
+    data[4] = R.data[3] * scale.x;
+    data[5] = R.data[4] * scale.y;
+    data[6] = R.data[5] * scale.z;
+    data[7] = pos.y;
+
+    data[8] = R.data[6] * scale.x;
+    data[9] = R.data[7] * scale.y;
+    data[10] = R.data[8] * scale.z;
+    data[11] = pos.z;
+
+    data[12] = 0;
+    data[13] = 0;
+    data[14] = 0;
+    data[15] = 1;
 }
 
+vec3 mat4::getPosition() const { return vec3(data[3], data[7], data[11]); }
+
 quat mat4::getOrientation() const {
-    quat q{};
-    vec3 scale = getScale();
+    quat resultQuat; // Default constructor initializes to identity (1, 0, 0, 0)
 
-    if (scale.x == 0 || scale.y == 0 || scale.z == 0) {
-        LOG_WARN("atta::quat", "Could not calculate orientation, scale component is zero");
-        return q;
+    // Extract scale from the lengths of the column vectors of the 3x3 rotation/scale part.
+    // Assumes data is row-major: data[0]=m00, data[1]=m01, ..., data[4]=m10, etc.
+    vec3 scale;
+    scale.x = length(vec3(data[0], data[4], data[8]));  // Length of first column vector (X-axis basis)
+    scale.y = length(vec3(data[1], data[5], data[9]));  // Length of second column vector (Y-axis basis)
+    scale.z = length(vec3(data[2], data[6], data[10])); // Length of third column vector (Z-axis basis)
+
+    // Define a small tolerance for checking near-zero scale
+    const float epsilon = std::numeric_limits<float>::epsilon() * 100;
+
+    // Check if any scale component is zero or very close to zero
+    if (std::abs(scale.x) < epsilon || std::abs(scale.y) < epsilon || std::abs(scale.z) < epsilon) {
+        // Cannot reliably extract orientation if scaling is zero along any axis
+        LOG_WARN("atta::mat4", "[w]getOrientation[] failed: Matrix has zero or near-zero scale component(s)");
+        return resultQuat; // Return identity quaternion
     }
 
-    double b1_squared = 0.25 * (1.0 + mat[0][0] / scale.x + mat[1][1] / scale.y + mat[2][2] / scale.z);
-    if (b1_squared > 0.0000001) {
-        double b1 = sqrt(b1_squared);
-        double over_b1_4 = 0.25 / b1;
-        double b2 = -(mat[2][1] / scale.y - mat[1][2] / scale.z) * over_b1_4;
-        double b3 = -(mat[0][2] / scale.z - mat[2][0] / scale.x) * over_b1_4;
-        double b4 = -(mat[1][0] / scale.x - mat[0][1] / scale.y) * over_b1_4;
-        q = quat(b1, b2, b3, b4);
-        q.normalize();
-    } else {
-        // Supress warning because it happens often when the entity scale is small
-        // LOG_WARN("atta::mat4", "[w](getOrientation)[] Could not calculate quaternion from [w]$0[], operations with very small number [w]$1[]", *this, b1_squared);
-    }
+    // Create the rotation matrix by dividing the columns by their respective scale factors.
+    mat3 rotationMatrix;
 
-    return q;
+    // Column 0
+    rotationMatrix.data[0] = data[0] / scale.x;
+    rotationMatrix.data[3] = data[4] / scale.x;
+    rotationMatrix.data[6] = data[8] / scale.x;
+
+    // Column 1
+    rotationMatrix.data[1] = data[1] / scale.y;
+    rotationMatrix.data[4] = data[5] / scale.y;
+    rotationMatrix.data[7] = data[9] / scale.y;
+
+    // Column 2
+    rotationMatrix.data[2] = data[2] / scale.z;
+    rotationMatrix.data[5] = data[6] / scale.z;
+    rotationMatrix.data[8] = data[10] / scale.z;
+
+    // Convert the pure rotation matrix to a quaternion
+    // The setRotationMatrix function should handle normalization
+    resultQuat.setRotationMatrix(rotationMatrix);
+
+    return resultQuat;
 }
 
 vec3 mat4::getScale() const {

--- a/src/atta/utils/math/matrix.cpp
+++ b/src/atta/utils/math/matrix.cpp
@@ -289,8 +289,13 @@ void mat4::invert() {
     setInverse(ori);
 }
 
-void mat4::transpose() {
+mat4 mat4::inverted() const {
+    mat4 ori;
+    ori.setInverse(*this);
+    return ori;
+}
 
+void mat4::transpose() {
     std::swap(data[1], data[4]);
     std::swap(data[2], data[8]);
     std::swap(data[3], data[12]);
@@ -299,6 +304,12 @@ void mat4::transpose() {
     std::swap(data[7], data[13]);
 
     std::swap(data[11], data[14]);
+}
+
+mat4 mat4::transposed() const {
+    mat4 result = *this;
+    result.transpose();
+    return result;
 }
 
 // Transform direction vector
@@ -674,14 +685,26 @@ void mat3::setInverse(const mat3& m) {
 
 // Inverts this matrix
 void mat3::invert() {
-    mat3 ori = *this;
-    setInverse(ori);
+    mat3 m = *this;
+    setInverse(m);
+}
+
+mat3 mat3::inverted() const {
+    mat3 m;
+    m.setInverse(*this);
+    return m;
 }
 
 void mat3::transpose() {
     std::swap(data[1], data[3]);
     std::swap(data[2], data[6]);
     std::swap(data[5], data[7]);
+}
+
+mat3 mat3::transposed() const {
+    mat3 result = *this;
+    result.transpose();
+    return result;
 }
 
 // Multiply matrices
@@ -881,7 +904,19 @@ void mat2::invert() {
     setInverse(ori);
 }
 
+mat2 mat2::inverted() const {
+    mat2 m;
+    m.setInverse(*this);
+    return m;
+}
+
 void mat2::transpose() { std::swap(data[1], data[2]); }
+
+mat2 mat2::transposed() const {
+    mat2 result = *this;
+    result.transpose();
+    return result;
+}
 
 // Multiply matrices
 mat2 mat2::operator*(const mat2& o) const {

--- a/src/atta/utils/math/matrix.h
+++ b/src/atta/utils/math/matrix.h
@@ -64,7 +64,10 @@ class mat4 {
     mat4 operator*(const float v) const;
 
     void invert();
+    mat4 inverted() const;
+
     void transpose();
+    mat4 transposed() const;
 
     vec3 transformDirection(const vec3& vector) const;
     vec3 transformInverseDirection(const vec3& vector) const;
@@ -223,8 +226,14 @@ class mat3 {
     // Inverts this matrix
     void invert();
 
+    // Get the inverted matrix
+    mat3 inverted() const;
+
     // Transpose this matrix
     void transpose();
+
+    // Get the transposed matrix
+    mat3 transposed() const;
 
     // Assing matrix
     // mat3 operator=(const mat3 &o);
@@ -302,8 +311,14 @@ class mat2 {
     // Inverts this matrix
     void invert();
 
+    // Get the inverted matrix
+    mat2 inverted() const;
+
     // Transpose this matrix
     void transpose();
+
+    // Get the transposed matrix
+    mat2 transposed() const;
 
     // Multiply matrices
     mat2 operator*(const mat2& o) const;

--- a/src/atta/utils/math/matrix.h
+++ b/src/atta/utils/math/matrix.h
@@ -165,7 +165,6 @@ inline mat4 rotationFromEuler(float R, float P, float Y) {
 inline mat4 posOri(const vec3& pos, const quat& q) {
     mat4 res;
     res.setPosOri(pos, q);
-
     return res;
 }
 
@@ -173,7 +172,6 @@ inline mat4 posOri(const vec3& pos, const quat& q) {
 inline mat4 posOriScale(const vec3& pos, const quat& q, const vec3& scale) {
     mat4 res;
     res.setPosOriScale(pos, q, scale);
-
     return res;
 }
 

--- a/src/atta/utils/math/quaternion.cpp
+++ b/src/atta/utils/math/quaternion.cpp
@@ -33,7 +33,7 @@ quat quat::normalized() const {
     return q;
 }
 
-void quat::inverse() {
+void quat::invert() {
     float d = r * r + i * i + j * j + k * k;
     // Check for zero length quaternion, and use the no-rotation
     // quaternion in that case
@@ -49,9 +49,9 @@ void quat::inverse() {
     k = -k / d;
 }
 
-quat quat::inversed() const {
+quat quat::inverted() const {
     quat q = *this;
-    q.inverse();
+    q.invert();
     return q;
 }
 

--- a/src/atta/utils/math/quaternion.cpp
+++ b/src/atta/utils/math/quaternion.cpp
@@ -59,8 +59,11 @@ quat quat::operator*(const quat& multiplier) const {
 }
 
 quat quat::operator-() const {
-    quat q = (*this);
-    q.r *= -1;
+    quat q;
+    q.r = -r;
+    q.i = -i;
+    q.j = -j;
+    q.k = -k;
     return q;
 }
 
@@ -111,7 +114,7 @@ void quat::addScaledVector(const vec3& vec, float scale) {
 
 void quat::rotateVector(vec3& vec) const {
     vec3 v = vec;
-    vec3 u = {-i, -j, -k};
+    vec3 u = {i, j, k};
     float s = r;
     vec = 2.0f * dot(u, v) * u + (s * s - dot(u, u)) * v + 2.0f * s * cross(u, v);
 }
@@ -121,8 +124,8 @@ void quat::rotateAroundAxis(const vec3& axis, float angle) {
     // The angle must be in radians
     // Counter clockwise rotation around the axis
     float halfAngle = angle / 2.0f;
-    float c = cos(halfAngle);
-    float s = sin(halfAngle);
+    float c = std::cos(halfAngle);
+    float s = std::sin(halfAngle);
     quat q(c, s * axis.x, s * axis.y, s * axis.z);
     q.normalize();
     normalize();
@@ -133,7 +136,7 @@ void quat::setRotationFromVectors(const vec3& before, const vec3& after) {
     // Given two vectors, return the quaternion representing the shortest rotation between the two vectors
     vec3 rotAxis = cross(before, after);
     float cosTheta = dot(before, after);
-    float halfAngle = acos(cosTheta) * 0.5f;
+    float halfAngle = std::acos(cosTheta) * 0.5f;
     // Degenerated cases
     if (cosTheta == 1) // Equal directions
         return;
@@ -146,8 +149,8 @@ void quat::setRotationFromVectors(const vec3& before, const vec3& after) {
             rotAxis = cross(before, vec3(1, 0, 0));
     }
     rotAxis.normalize();
-    float cosHalfAngle = cos(halfAngle);
-    float sinHalfAngle = sin(halfAngle);
+    float cosHalfAngle = std::cos(halfAngle);
+    float sinHalfAngle = std::sin(halfAngle);
 
     // Create rotation quaternion
     r = cosHalfAngle;
@@ -158,10 +161,10 @@ void quat::setRotationFromVectors(const vec3& before, const vec3& after) {
 
 void quat::setEuler(const vec3& e) {
     // ZYX euler
-    r = cos(e.x / 2.0) * cos(e.y / 2.0) * cos(e.z / 2.0) + sin(e.x / 2.0) * sin(e.y / 2.0) * sin(e.z / 2.0);
-    i = sin(e.x / 2.0) * cos(e.y / 2.0) * cos(e.z / 2.0) - cos(e.x / 2.0) * sin(e.y / 2.0) * sin(e.z / 2.0);
-    j = cos(e.x / 2.0) * sin(e.y / 2.0) * cos(e.z / 2.0) + sin(e.x / 2.0) * cos(e.y / 2.0) * sin(e.z / 2.0);
-    k = cos(e.x / 2.0) * cos(e.y / 2.0) * sin(e.z / 2.0) - sin(e.x / 2.0) * sin(e.y / 2.0) * cos(e.z / 2.0);
+    r = std::cos(e.x / 2.0) * std::cos(e.y / 2.0) * std::cos(e.z / 2.0) + std::sin(e.x / 2.0) * std::sin(e.y / 2.0) * std::sin(e.z / 2.0);
+    i = std::sin(e.x / 2.0) * std::cos(e.y / 2.0) * std::cos(e.z / 2.0) - std::cos(e.x / 2.0) * std::sin(e.y / 2.0) * std::sin(e.z / 2.0);
+    j = std::cos(e.x / 2.0) * std::sin(e.y / 2.0) * std::cos(e.z / 2.0) + std::sin(e.x / 2.0) * std::cos(e.y / 2.0) * std::sin(e.z / 2.0);
+    k = std::cos(e.x / 2.0) * std::cos(e.y / 2.0) * std::sin(e.z / 2.0) - std::sin(e.x / 2.0) * std::sin(e.y / 2.0) * std::cos(e.z / 2.0);
     normalize();
 }
 
@@ -180,19 +183,19 @@ vec3 quat::getEuler() const {
 
 void quat::set2DAngle(float angle) {
     // ZYX euler
-    r = cos(-angle / 2.0);
+    r = std::cos(-angle / 2.0);
     i = 0;
     j = 0;
-    k = sin(-angle / 2.0);
+    k = std::sin(-angle / 2.0);
 }
 
-float quat::get2DAngle() const { return -atan2(2.0 * (r * k + i * j), 1 - 2.0 * (j * j + k * k)); }
+float quat::get2DAngle() const { return -std::atan2(2.0 * (r * k + i * j), 1 - 2.0 * (j * j + k * k)); }
 
 void quat::setAxisAngle(const vec3& v, float angle) {
     vec3 axis = atta::normalize(v);
     float halfAngle = angle / 2.0f;
-    float c = cos(halfAngle);
-    float s = sin(halfAngle);
+    float c = std::cos(halfAngle);
+    float s = std::sin(halfAngle);
     r = c;
     i = s * axis.x;
     j = s * axis.y;
@@ -203,7 +206,7 @@ void quat::getAxisAngle(vec3& v, float& angle) const {
     vec3 result;
     quat q = *this;
     q.normalize();
-    float s = sqrt(1 - r * r);
+    float s = std::sqrt(1 - r * r);
     if (s < 0.001) {
         result.x = q.i;
         result.y = q.j;
@@ -214,7 +217,7 @@ void quat::getAxisAngle(vec3& v, float& angle) const {
         result.z = q.k / s;
     }
     v = result;
-    angle = 2 * acos(r);
+    angle = 2 * std::acos(r);
 }
 
 mat3 quat::getRotationMatrix() const {

--- a/src/atta/utils/math/quaternion.cpp
+++ b/src/atta/utils/math/quaternion.cpp
@@ -55,6 +55,20 @@ quat quat::operator*(const quat& other) const {
     return result;
 }
 
+// vec3 multiplication
+void quat::rotateVector(vec3& vec) const {
+    vec3 v = vec;
+    vec3 u = {i, j, k};
+    float s = r;
+    vec = 2.0f * dot(u, v) * u + (s * s - dot(u, u)) * v + 2.0f * s * cross(u, v);
+}
+
+vec3 quat::operator*(const vec3& vec) const {
+    vec3 result = vec;
+    rotateVector(result);
+    return result;
+}
+
 quat quat::operator-() const {
     quat q;
     q.r = -r;
@@ -107,13 +121,6 @@ void quat::addScaledVector(const vec3& vec, float scale) {
     i += q.i * 0.5f;
     j += q.j * 0.5f;
     k += q.k * 0.5f;
-}
-
-void quat::rotateVector(vec3& vec) const {
-    vec3 v = vec;
-    vec3 u = {i, j, k};
-    float s = r;
-    vec = 2.0f * dot(u, v) * u + (s * s - dot(u, u)) * v + 2.0f * s * cross(u, v);
 }
 
 void quat::rotateAroundAxis(const vec3& axis, float angle) {

--- a/src/atta/utils/math/quaternion.cpp
+++ b/src/atta/utils/math/quaternion.cpp
@@ -27,6 +27,12 @@ void quat::normalize() {
     k *= d;
 }
 
+quat quat::normalized() const {
+    quat q = *this;
+    q.normalize();
+    return q;
+}
+
 void quat::inverse() {
     float d = r * r + i * i + j * j + k * k;
     // Check for zero length quaternion, and use the no-rotation
@@ -41,6 +47,12 @@ void quat::inverse() {
     i = -i / d;
     j = -j / d;
     k = -k / d;
+}
+
+quat quat::inversed() const {
+    quat q = *this;
+    q.inverse();
+    return q;
 }
 
 // quat multiplication

--- a/src/atta/utils/math/quaternion.cpp
+++ b/src/atta/utils/math/quaternion.cpp
@@ -182,14 +182,13 @@ vec3 quat::getEuler() const {
 }
 
 void quat::set2DAngle(float angle) {
-    // ZYX euler
-    r = std::cos(-angle / 2.0);
+    r = std::cos(angle / 2.0);
     i = 0;
     j = 0;
-    k = std::sin(-angle / 2.0);
+    k = std::sin(angle / 2.0);
 }
 
-float quat::get2DAngle() const { return -std::atan2(2.0 * (r * k + i * j), 1 - 2.0 * (j * j + k * k)); }
+float quat::get2DAngle() const { return std::atan2(2.0 * (r * k + i * j), 1 - 2.0 * (j * j + k * k)); }
 
 void quat::setAxisAngle(const vec3& v, float angle) {
     vec3 axis = atta::normalize(v);
@@ -203,10 +202,10 @@ void quat::setAxisAngle(const vec3& v, float angle) {
 }
 
 void quat::getAxisAngle(vec3& v, float& angle) const {
-    vec3 result;
     quat q = *this;
     q.normalize();
-    float s = std::sqrt(1 - r * r);
+    float s = std::sqrt(1 - q.r * q.r);
+    vec3 result;
     if (s < 0.001) {
         result.x = q.i;
         result.y = q.j;
@@ -217,7 +216,7 @@ void quat::getAxisAngle(vec3& v, float& angle) const {
         result.z = q.k / s;
     }
     v = result;
-    angle = 2 * std::acos(r);
+    angle = 2 * std::acos(q.r);
 }
 
 mat3 quat::getRotationMatrix() const {
@@ -234,7 +233,6 @@ mat3 quat::getRotationMatrix() const {
     result.mat[2][1] = 2 * (j * k + r * i);
     result.mat[2][2] = 2 * (r * r + k * k) - 1;
 
-    result.transpose();
     return result;
 }
 

--- a/src/atta/utils/math/quaternion.cpp
+++ b/src/atta/utils/math/quaternion.cpp
@@ -44,17 +44,14 @@ void quat::inverse() {
 }
 
 // quat multiplication
-void quat::operator*=(const quat& multiplier) {
-    quat q = *this;
-    r = q.r * multiplier.r - q.i * multiplier.i - q.j * multiplier.j - q.k * multiplier.k;
-    i = q.r * multiplier.i + q.i * multiplier.r + q.j * multiplier.k - q.k * multiplier.j;
-    j = q.r * multiplier.j + q.j * multiplier.r + q.k * multiplier.i - q.i * multiplier.k;
-    k = q.r * multiplier.k + q.k * multiplier.r + q.i * multiplier.j - q.j * multiplier.i;
-}
+void quat::operator*=(const quat& q2) { *this = (*this) * q2; }
 
-quat quat::operator*(const quat& multiplier) const {
-    quat result = (*this);
-    result *= multiplier;
+quat quat::operator*(const quat& other) const {
+    quat result;
+    result.r = r * other.r - i * other.i - j * other.j - k * other.k;
+    result.i = r * other.i + i * other.r + j * other.k - k * other.j;
+    result.j = r * other.j + j * other.r + k * other.i - i * other.k;
+    result.k = r * other.k + k * other.r + i * other.j - j * other.i;
     return result;
 }
 

--- a/src/atta/utils/math/quaternion.h
+++ b/src/atta/utils/math/quaternion.h
@@ -25,8 +25,8 @@ class quat {
     void normalize();
     quat normalized() const;
 
-    void inverse();
-    quat inversed() const;
+    void invert();
+    quat inverted() const;
 
     // Quaternion multiplication (note that in q1 * q2, the q2 rotation is applied first, then q1)
     void operator*=(const quat& quat);
@@ -76,10 +76,7 @@ inline vec3 quatToEuler(const quat& q) {
     return e;
 }
 
-inline quat inverse(quat q) {
-    q.inverse();
-    return q;
-}
+inline quat inverse(quat q) { return q.inverted(); }
 
 // <<
 inline std::ostream& operator<<(std::ostream& os, const quat& q) { return os << q.toString(); }

--- a/src/atta/utils/math/quaternion.h
+++ b/src/atta/utils/math/quaternion.h
@@ -25,9 +25,9 @@ class quat {
     void normalize();
     void inverse();
 
-    // quat multiplication
-    void operator*=(const quat& multiplier);
-    quat operator*(const quat& multiplier) const;
+    // Quaternion multiplication (note that in q1 * q2, the q2 rotation is applied first, then q1)
+    void operator*=(const quat& quat);
+    quat operator*(const quat& quat) const;
     quat operator-() const;
 
     // Multiply scalar

--- a/src/atta/utils/math/quaternion.h
+++ b/src/atta/utils/math/quaternion.h
@@ -53,6 +53,7 @@ class quat {
     float get2DAngle() const;
     void setAxisAngle(const vec3& v, float angle);
     void getAxisAngle(vec3& v, float& angle) const;
+    void setRotationMatrix(const mat3& R);
     mat3 getRotationMatrix() const;
 
     std::string toString() const;

--- a/src/atta/utils/math/quaternion.h
+++ b/src/atta/utils/math/quaternion.h
@@ -36,13 +36,16 @@ class quat {
     template <typename U>
     quat operator*(const U value) const;
 
+    // Multiply vector
+    void rotateVector(vec3& vec) const;
+    vec3 operator*(const vec3& vec) const;
+
     void operator+=(const vec3& vec);
 
     // Logical operators
     bool operator==(const quat& other) const;
     bool operator!=(const quat& other) const;
 
-    void rotateVector(vec3& vec) const;
     void addScaledVector(const vec3& vec, float scale);
     void rotateAroundAxis(const vec3& axis, float angle);
 

--- a/src/atta/utils/math/quaternion.h
+++ b/src/atta/utils/math/quaternion.h
@@ -19,11 +19,14 @@ class quat {
     float k; // Third complex
 
     quat() : r(1), i(0), j(0), k(0) {}
-    quat(const vec3& v) { setEuler(v); }
+    explicit quat(const vec3& v) { setEuler(v); }
     quat(const float r, const float i, const float j, const float k) : r(r), i(i), j(j), k(k) {}
 
     void normalize();
+    quat normalized() const;
+
     void inverse();
+    quat inversed() const;
 
     // Quaternion multiplication (note that in q1 * q2, the q2 rotation is applied first, then q1)
     void operator*=(const quat& quat);

--- a/src/atta/utils/math/vector.h
+++ b/src/atta/utils/math/vector.h
@@ -95,6 +95,7 @@ class vector4 {
 
     // Normalize
     void normalize();
+    vector4<T> normalized() const;
 
     // Unit
     vector4<T> unit() const;
@@ -234,6 +235,7 @@ class vector3 {
 
     // Normalize
     void normalize();
+    vector3<T> normalized() const;
 
     // Unit
     vector3<T> unit() const;
@@ -376,6 +378,7 @@ class vector2 {
 
     // Normalize
     void normalize();
+    vector2<T> normalized() const;
 
     // Unit
     vector2<T> unit() const;

--- a/src/atta/utils/math/vector2.inl
+++ b/src/atta/utils/math/vector2.inl
@@ -160,6 +160,14 @@ void vector2<T>::normalize() {
         (*this) *= 1.0f / l;
 }
 
+// Normalized
+template <typename T>
+vector2<T> vector2<T>::normalized() const {
+    vector2<T> result = *this;
+    result.normalize();
+    return result;
+}
+
 // Unit
 template <typename T>
 vector2<T> vector2<T>::unit() const {

--- a/src/atta/utils/math/vector3.inl
+++ b/src/atta/utils/math/vector3.inl
@@ -274,6 +274,14 @@ inline vector3<T> normalize(const vector3<T>& v) {
     return v;
 }
 
+// Normalized
+template <typename T>
+vector3<T> vector3<T>::normalized() const {
+    vector3<T> result = *this;
+    result.normalize();
+    return result;
+}
+
 // Dot
 template <typename T>
 inline auto dot(const vector3<T>& v1, const vector3<T>& v2) {

--- a/src/atta/utils/math/vector4.inl
+++ b/src/atta/utils/math/vector4.inl
@@ -171,6 +171,14 @@ void vector4<T>::normalize() {
         (*this) *= 1.0f / l;
 }
 
+// Normalized
+template <typename T>
+vector4<T> vector4<T>::normalized() const {
+    vector4<T> result = *this;
+    result.normalize();
+    return result;
+}
+
 // Unit
 template <typename T>
 vector4<T> vector4<T>::unit() const {

--- a/src/atta/utils/tests/matrix.cpp
+++ b/src/atta/utils/tests/matrix.cpp
@@ -1,0 +1,249 @@
+//--------------------------------------------------
+// Atta Math Tests
+// matrix.cpp
+// Date: 2025-04-12
+// By: Breno Cunha Queiroz
+//--------------------------------------------------
+#include <atta/utils/math/matrix.h>
+#include <cmath>
+#include <gtest/gtest.h>
+
+using namespace atta;
+
+namespace {
+// Helper: Compare two vec3 using EXPECT_NEAR for each component
+void expectVec3Equal(const vec3& a, const vec3& b, float tol = 1e-5f) {
+    EXPECT_NEAR(a.x, b.x, tol);
+    EXPECT_NEAR(a.y, b.y, tol);
+    EXPECT_NEAR(a.z, b.z, tol);
+}
+
+//===========================================================================
+// Tests for mat4
+//===========================================================================
+
+TEST(Utils_Mat4, DefaultConstructor) {
+    mat4 m;
+    // Default constructor sets all elements to zero
+    for (int i = 0; i < 16; i++) {
+        EXPECT_FLOAT_EQ(m.data[i], 0.0f);
+    }
+}
+
+TEST(Utils_Mat4, DiagonalConstructorIdentity) {
+    mat4 id(1.0f);
+    // Identity matrix expected: diagonal elements 1, others 0.
+    EXPECT_FLOAT_EQ(id.data[0], 1.0f);
+    EXPECT_FLOAT_EQ(id.data[5], 1.0f);
+    EXPECT_FLOAT_EQ(id.data[10], 1.0f);
+    EXPECT_FLOAT_EQ(id.data[15], 1.0f);
+    for (int i = 0; i < 16; i++) {
+        // Check off-diagonals for zero
+        if (i != 0 && i != 5 && i != 10 && i != 15)
+            EXPECT_FLOAT_EQ(id.data[i], 0.0f);
+    }
+}
+
+TEST(Utils_Mat4, CopyConstructorAndAssignment) {
+    mat4 m1(1.0f);
+    mat4 m2 = m1;
+    for (int i = 0; i < 16; i++) {
+        EXPECT_FLOAT_EQ(m1.data[i], m2.data[i]);
+    }
+
+    mat4 m3;
+    m3 = m1;
+    for (int i = 0; i < 16; i++) {
+        EXPECT_FLOAT_EQ(m3.data[i], m1.data[i]);
+    }
+}
+
+TEST(Utils_Mat4, MultiplicationIdentity) {
+    mat4 id(1.0f);
+    // Multiply identity with a translation matrix.
+    vec3 trans(1.0f, 2.0f, 3.0f);
+    mat4 t = posOri(trans, quat()); // quat() is identity rotation.
+    mat4 res = id * t;
+    // Should equal t.
+    EXPECT_FLOAT_EQ(res.data[3], t.data[3]);   // x translation
+    EXPECT_FLOAT_EQ(res.data[7], t.data[7]);   // y translation
+    EXPECT_FLOAT_EQ(res.data[11], t.data[11]); // z translation
+}
+
+TEST(Utils_Mat4, TransformVector) {
+    // Build a translation matrix and test transform on a point.
+    vec3 pos(10.0f, 20.0f, 30.0f);
+    // Identity quaternion gives no rotation.
+    mat4 transform = posOri(pos, quat());
+    vec3 point(1.0f, 1.0f, 1.0f);
+    // Apply transform: since there is no rotation/scaling,
+    // the result should be point + pos.
+    vec3 transformed = transform.transform(point);
+    expectVec3Equal(transformed, pos + point);
+}
+
+TEST(Utils_Mat4, Transpose) {
+    // Create a non-symmetric matrix and test its transpose.
+    mat4 m(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f);
+    mat4 t = m;
+    t.transpose();
+
+    // Check that t(i,j) = m(j,i)
+    EXPECT_FLOAT_EQ(t.mat[0][1], m.mat[1][0]);
+    EXPECT_FLOAT_EQ(t.mat[1][2], m.mat[2][1]);
+    EXPECT_FLOAT_EQ(t.mat[2][3], m.mat[3][2]);
+}
+
+TEST(Utils_Mat4, Inverse) {
+    // Create a matrix that is a combination of translation and scaling,
+    // and compute its inverse. Verify that multiplying a matrix by its inverse gives identity.
+    vec3 pos(3.0f, -4.0f, 5.0f);
+    quat rot;
+    rot.setEuler(vec3(0.2f, 0.3f, 0.4f));
+    vec3 scale(2.0f, 3.0f, 4.0f);
+    mat4 m = posOriScale(pos, rot, scale);
+    mat4 inv = m;
+    inv.setInverse(m);
+    mat4 identity = m * inv;
+
+    // Check that the identity's diagonal elements are near 1 and off-diagonals near 0.
+    EXPECT_NEAR(identity.data[0], 1.0f, 1e-3f);
+    EXPECT_NEAR(identity.data[5], 1.0f, 1e-3f);
+    EXPECT_NEAR(identity.data[10], 1.0f, 1e-3f);
+    EXPECT_NEAR(identity.data[15], 1.0f, 1e-3f);
+    EXPECT_NEAR(identity.data[1], 0.0f, 1e-3f);
+    EXPECT_NEAR(identity.data[2], 0.0f, 1e-3f);
+    EXPECT_NEAR(identity.data[3], 0.0f, 1e-3f);
+}
+
+TEST(Utils_Mat4, GetPositionOrientationScale) {
+    // Set a matrix from position, orientation, and scale.
+    vec3 pos(1.0f, 2.0f, 3.0f);
+    quat q;
+    q.setEuler(vec3(0.1f, 0.2f, 0.3f)); // Some rotation.
+    vec3 scale(1.0f, 2.0f, 3.0f);
+    mat4 m;
+    m.setPosOriScale(pos, q, scale);
+    vec3 outPos;
+    quat outQ;
+    vec3 outScale;
+    m.getPosOriScale(outPos, outQ, outScale);
+
+    expectVec3Equal(pos, outPos, 1e-2f);
+    expectVec3Equal(scale, outScale, 1e-2f);
+
+    // Check if quaternions match
+    EXPECT_NEAR(std::abs(q.i - outQ.i), 0.0f, 1e-3f);
+    EXPECT_NEAR(std::abs(q.j - outQ.j), 0.0f, 1e-3f);
+    EXPECT_NEAR(std::abs(q.k - outQ.k), 0.0f, 1e-3f);
+    EXPECT_NEAR(std::abs(q.r - outQ.r), 0.0f, 1e-3f);
+}
+
+TEST(Utils_Mat4, TransformPoint) {
+    // Create a transformation matrix with:
+    //   Translation: pos = (3,4,5)
+    //   Rotation: 90 degrees about Z-axis
+    //   Scale: (2, 2, 2)
+    vec3 pos(3.0f, 4.0f, 5.0f);
+    vec3 scale(2.0f, 2.0f, 2.0f);
+    float angle = M_PI / 2.0f; // 90 degrees
+    quat q;
+    q.setAxisAngle(vec3(0, 0, 1), angle);
+    // Build transformation matrix (pos, rotation, scale)
+    mat4 transform = posOriScale(pos, q, scale);
+
+    // Create a test point p = (1,0,0) (in world coordinates)
+    vec3 p(1.0f, 0.0f, 0.0f);
+
+    // Expected transformation:
+    // 1. Scale (1,0,0) by (2,2,2) --> (2,0,0)
+    // 2. Rotate (2,0,0) by 90° about Z-axis --> (0,2,0)
+    // 3. Translate by (3,4,5) --> (3+0, 4+2, 5+0) = (3,6,5)
+    vec3 expected(3.0f, 6.0f, 5.0f);
+
+    // Transform p using our matrix:
+    vec3 result = transform.transform(p);
+    expectVec3Equal(result, expected);
+}
+
+TEST(Utils_Mat4, ConcatTransform) {
+    // Construct two transformations:
+    // A: Pure translation by (1, 1, 1).
+    vec3 transA(1.0f, 1.0f, 1.0f);
+    // Use identity rotation and scale.
+    mat4 A = posOri(transA, quat()); // using identity quaternion implicitly
+    // B: Transformation that scales by (2,2,2) and rotates 90° about Z,
+    //    with no translation.
+    vec3 transB(0.0f, 0.0f, 0.0f);
+    vec3 scaleB(2.0f, 2.0f, 2.0f);
+    float angle = M_PI / 2.0f; // 90 degrees rotation
+    quat qB;
+    qB.setAxisAngle(vec3(0, 0, 1), angle);
+    mat4 B = posOriScale(transB, qB, scaleB);
+
+    // Concatenate the transformations. Assuming operator* means:
+    //   T = A * B, so that point p is transformed as: p' = A * (B * p)
+    mat4 T = A * B;
+
+    // Choose a point p
+    vec3 p(1.0f, 0.0f, 0.0f);
+
+    // Calculate expected transformation:
+    // First, apply B:
+    //   p scaled: (1,0,0) * (2,2,2) -> (2,0,0)
+    //   Rotated by 90° about Z: (2,0,0) -> (0,2,0)
+    //   B has no translation.
+    // Then, apply A: simply a translation by (1,1,1):
+    //   (0,2,0) + (1,1,1) = (1,3,1)
+    vec3 expected(1.0f, 3.0f, 1.0f);
+
+    vec3 result = T.transform(p);
+    expectVec3Equal(result, expected);
+}
+
+//===========================================================================
+// Tests for mat3
+//===========================================================================
+
+TEST(Utils_Mat3, DefaultConstructor) {
+    mat3 m;
+    for (int i = 0; i < 9; i++) {
+        EXPECT_FLOAT_EQ(m.data[i], 0.0f);
+    }
+}
+
+TEST(Utils_Mat3, DiagonalConstructorIdentity) {
+    mat3 id(1.0f);
+    EXPECT_FLOAT_EQ(id.data[0], 1.0f);
+    EXPECT_FLOAT_EQ(id.data[4], 1.0f);
+    EXPECT_FLOAT_EQ(id.data[8], 1.0f);
+    for (int i = 0; i < 9; i++) {
+        if (i != 0 && i != 4 && i != 8)
+            EXPECT_FLOAT_EQ(id.data[i], 0.0f);
+    }
+}
+
+TEST(Utils_Mat3, Multiplication) {
+    // Test a simple multiplication:
+    // Let m1 = [1 2 3; 4 5 6; 7 8 9] and m2 = [9 8 7; 6 5 4; 3 2 1]
+    mat3 m1(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    mat3 m2(9, 8, 7, 6, 5, 4, 3, 2, 1);
+    mat3 prod = m1 * m2;
+    // Precomputed expected results:
+    // prod[0] = 1*9 + 2*6 + 3*3 = 9 + 12 + 9 = 30
+    // prod[1] = 1*8 + 2*5 + 3*2 = 8 + 10 + 6 = 24
+    // prod[2] = 1*7 + 2*4 + 3*1 = 7 + 8 + 3 = 18
+    EXPECT_NEAR(prod.data[0], 30.0f, 1e-3f);
+    EXPECT_NEAR(prod.data[1], 24.0f, 1e-3f);
+    EXPECT_NEAR(prod.data[2], 18.0f, 1e-3f);
+}
+
+TEST(Utils_Mat3, Transpose) {
+    mat3 m(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    mat3 t = m;
+    t.transpose();
+    // In the transposed matrix, element at (row=0, col=1) should be original (row=1, col=0)
+    EXPECT_FLOAT_EQ(t.data[1], m.data[3]);
+    EXPECT_FLOAT_EQ(t.data[3], m.data[1]);
+}
+} // namespace

--- a/src/atta/utils/tests/quaternion.cpp
+++ b/src/atta/utils/tests/quaternion.cpp
@@ -33,10 +33,10 @@ TEST(Utils_Quaternion, Normalization) {
     EXPECT_FLOAT_EQ(qZero.k, 0.0f);
 }
 
-TEST(Utils_Quaternion, Inverse) {
+TEST(Utils_Quaternion, Invert) {
     quat q(0.7071f, 0.7071f, 0.0f, 0.0f); // Normalized 90deg rotation around X
     quat qInv = q;
-    qInv.inverse();
+    qInv.invert();
     quat identity = q * qInv;
     // The product of a quaternion and its inverse should be approximately the identity quaternion
     EXPECT_NEAR(identity.r, 1.0f, 1e-6f);
@@ -46,7 +46,7 @@ TEST(Utils_Quaternion, Inverse) {
 
     // Test inverse of near-zero quaternion (should become identity)
     quat qZero(0.0f, 0.0f, 0.0f, 0.0f);
-    qZero.inverse();
+    qZero.invert();
     EXPECT_FLOAT_EQ(qZero.r, 1.0f);
     EXPECT_FLOAT_EQ(qZero.i, 0.0f);
     EXPECT_FLOAT_EQ(qZero.j, 0.0f);

--- a/src/atta/utils/tests/quaternion.cpp
+++ b/src/atta/utils/tests/quaternion.cpp
@@ -1,0 +1,120 @@
+//--------------------------------------------------
+// Atta Math Tests
+// quaternion.cpp
+// Date: 2025-04-12
+// By: Breno Cunha Queiroz
+//--------------------------------------------------
+#include "atta/utils/math/quaternion.h"
+#include "atta/utils/math/matrix.h"
+#include "atta/utils/math/vector.h"
+#include <cmath>
+#include <gtest/gtest.h>
+
+using namespace atta;
+
+namespace {
+TEST(Utils_Quaternion, DefaultConstructor) {
+    quat q;
+    // Default quaternion should be the identity: (1, 0, 0, 0)
+    EXPECT_FLOAT_EQ(q.r, 1.0f);
+    EXPECT_FLOAT_EQ(q.i, 0.0f);
+    EXPECT_FLOAT_EQ(q.j, 0.0f);
+    EXPECT_FLOAT_EQ(q.k, 0.0f);
+}
+
+TEST(Utils_Quaternion, Normalization) {
+    quat q(0.0f, 1.0f, 2.0f, 3.0f);
+    q.normalize();
+    float norm = std::sqrt(q.r * q.r + q.i * q.i + q.j * q.j + q.k * q.k);
+    EXPECT_NEAR(norm, 1.0f, 1e-5f);
+}
+
+TEST(Utils_Quaternion, Inverse) {
+    quat q(0.7071f, 0.7071f, 0.0f, 0.0f);
+    quat qCopy = q;
+    qCopy.inverse();
+    quat identity = q * qCopy;
+    // The product of a quaternion and its inverse should be approximately the identity quaternion.
+    EXPECT_NEAR(identity.r, 1.0f, 1e-4f);
+    EXPECT_NEAR(identity.i, 0.0f, 1e-4f);
+    EXPECT_NEAR(identity.j, 0.0f, 1e-4f);
+    EXPECT_NEAR(identity.k, 0.0f, 1e-4f);
+}
+
+TEST(Utils_Quaternion, Multiplication) {
+    // Using two quaternions that represent 90-degree rotations around different axes.
+    quat q1(0.7071f, 0.7071f, 0.0f, 0.0f);
+    quat q2(0.7071f, 0.0f, 0.7071f, 0.0f);
+    q1.normalize();
+    q2.normalize();
+    quat q3 = q1 * q2;
+    // Expected result: (0.5, 0.5, 0.5, 0.5)
+    EXPECT_NEAR(q3.r, 0.5f, 1e-3f);
+    EXPECT_NEAR(q3.i, 0.5f, 1e-3f);
+    EXPECT_NEAR(q3.j, 0.5f, 1e-3f);
+    EXPECT_NEAR(q3.k, 0.5f, 1e-3f);
+}
+
+TEST(Utils_Quaternion, EulerConversion) {
+    // Test converting Euler angles to quaternion and back
+    vec3 euler(0.5f, 0.6f, 0.7f);
+    quat q;
+    q.setEuler(euler);
+    vec3 euler2 = q.getEuler();
+    // Allow some tolerance because of potential numerical differences and wrapping.
+    EXPECT_NEAR(euler.x, euler2.x, 1e-3f);
+    EXPECT_NEAR(euler.y, euler2.y, 1e-3f);
+    EXPECT_NEAR(euler.z, euler2.z, 1e-3f);
+}
+
+TEST(Utils_Quaternion, RotateVector) {
+    // Rotate a vector by a quaternion representing a 90-degree rotation about the Z axis.
+    float angle = M_PI / 2.0f; // 90 degrees in radians
+    quat q;
+    q.setAxisAngle(vec3(0, 0, 1), angle);
+    vec3 v(1, 0, 0);
+    q.rotateVector(v);
+    // The expected rotated vector should be approximately (0, 1, 0)
+    EXPECT_NEAR(v.x, 0.0f, 1e-3f);
+    EXPECT_NEAR(v.y, 1.0f, 1e-3f);
+    EXPECT_NEAR(v.z, 0.0f, 1e-3f);
+}
+
+TEST(Utils_Quaternion, AxisAngleConversion) {
+    // Create a quaternion from an axis-angle representation and then extract the axis and angle.
+    vec3 axis(1, 0, 0);
+    float angle = M_PI / 4.0f; // 45 degrees
+    quat q;
+    q.setAxisAngle(axis, angle);
+    vec3 resAxis;
+    float resAngle;
+    q.getAxisAngle(resAxis, resAngle);
+    // The axis should be (1,0,0) and the angle should be close to 45 degrees.
+    EXPECT_NEAR(std::abs(resAxis.x), 1.0f, 1e-3f);
+    EXPECT_NEAR(std::abs(resAxis.y), 0.0f, 1e-3f);
+    EXPECT_NEAR(std::abs(resAxis.z), 0.0f, 1e-3f);
+    EXPECT_NEAR(resAngle, angle, 1e-3f);
+}
+
+TEST(Utils_Quaternion, Negation) {
+    quat q(0.5f, 0.5f, 0.5f, 0.5f);
+    quat negQ = -q;
+    EXPECT_NEAR(negQ.r, -0.5f, 1e-3f);
+    EXPECT_NEAR(negQ.i, -0.5f, 1e-3f);
+    EXPECT_NEAR(negQ.j, -0.5f, 1e-3f);
+    EXPECT_NEAR(negQ.k, -0.5f, 1e-3f);
+}
+
+TEST(Utils_Quaternion, AddScaledVector) {
+    // Start with the identity quaternion and add a small rotation via a scaled vector.
+    quat q;
+    vec3 smallRotation(0.1f, 0.2f, 0.3f);
+    float scale = 0.05f;
+    q.addScaledVector(smallRotation, scale);
+    // The quaternion should now differ slightly from the identity.
+    // We check that its normalized result is still a unit quaternion.
+    q.normalize();
+    float norm = std::sqrt(q.r * q.r + q.i * q.i + q.j * q.j + q.k * q.k);
+    EXPECT_NEAR(norm, 1.0f, 1e-5f);
+}
+} // namespace

--- a/src/atta/utils/tests/quaternion.cpp
+++ b/src/atta/utils/tests/quaternion.cpp
@@ -12,7 +12,6 @@ using namespace atta;
 namespace {
 TEST(Utils_Quaternion, DefaultConstructor) {
     quat q;
-    // Default quaternion should be the identity: (1, 0, 0, 0)
     EXPECT_FLOAT_EQ(q.r, 1.0f);
     EXPECT_FLOAT_EQ(q.i, 0.0f);
     EXPECT_FLOAT_EQ(q.j, 0.0f);
@@ -24,44 +23,81 @@ TEST(Utils_Quaternion, Normalization) {
     q.normalize();
     float norm = std::sqrt(q.r * q.r + q.i * q.i + q.j * q.j + q.k * q.k);
     EXPECT_NEAR(norm, 1.0f, 1e-5f);
+
+    // Test normalization of near-zero quaternion
+    quat qZero(0.0f, 0.0f, 0.0f, 0.0f);
+    qZero.normalize();
+    EXPECT_FLOAT_EQ(qZero.r, 1.0f);
+    EXPECT_FLOAT_EQ(qZero.i, 0.0f);
+    EXPECT_FLOAT_EQ(qZero.j, 0.0f);
+    EXPECT_FLOAT_EQ(qZero.k, 0.0f);
 }
 
 TEST(Utils_Quaternion, Inverse) {
-    quat q(0.7071f, 0.7071f, 0.0f, 0.0f);
-    quat qCopy = q;
-    qCopy.inverse();
-    quat identity = q * qCopy;
-    // The product of a quaternion and its inverse should be approximately the identity quaternion.
-    EXPECT_NEAR(identity.r, 1.0f, 1e-4f);
-    EXPECT_NEAR(identity.i, 0.0f, 1e-4f);
-    EXPECT_NEAR(identity.j, 0.0f, 1e-4f);
-    EXPECT_NEAR(identity.k, 0.0f, 1e-4f);
+    quat q(0.7071f, 0.7071f, 0.0f, 0.0f); // Normalized 90deg rotation around X
+    quat qInv = q;
+    qInv.inverse();
+    quat identity = q * qInv;
+    // The product of a quaternion and its inverse should be approximately the identity quaternion
+    EXPECT_NEAR(identity.r, 1.0f, 1e-6f);
+    EXPECT_NEAR(identity.i, 0.0f, 1e-6f);
+    EXPECT_NEAR(identity.j, 0.0f, 1e-6f);
+    EXPECT_NEAR(identity.k, 0.0f, 1e-6f);
+
+    // Test inverse of near-zero quaternion (should become identity)
+    quat qZero(0.0f, 0.0f, 0.0f, 0.0f);
+    qZero.inverse();
+    EXPECT_FLOAT_EQ(qZero.r, 1.0f);
+    EXPECT_FLOAT_EQ(qZero.i, 0.0f);
+    EXPECT_FLOAT_EQ(qZero.j, 0.0f);
+    EXPECT_FLOAT_EQ(qZero.k, 0.0f);
 }
 
 TEST(Utils_Quaternion, Multiplication) {
-    // Using two quaternions that represent 90-degree rotations around different axes.
-    quat q1(0.7071f, 0.7071f, 0.0f, 0.0f);
-    quat q2(0.7071f, 0.0f, 0.7071f, 0.0f);
-    q1.normalize();
-    q2.normalize();
+    // q1: 90 degrees around X axis
+    quat q1;
+    q1.setAxisAngle(vec3(1.0f, 0.0f, 0.0f), M_PI / 2.0f);
+    // q2: 90 degrees around Y axis
+    quat q2;
+    q2.setAxisAngle(vec3(0.0f, 1.0f, 0.0f), M_PI / 2.0f);
+
     quat q3 = q1 * q2;
-    // Expected result: (0.5, 0.5, 0.5, 0.5)
-    EXPECT_NEAR(q3.r, 0.5f, 1e-3f);
-    EXPECT_NEAR(q3.i, 0.5f, 1e-3f);
-    EXPECT_NEAR(q3.j, 0.5f, 1e-3f);
-    EXPECT_NEAR(q3.k, 0.5f, 1e-3f);
+    // Expected result from q1*q2 (verified calculation): (0.5, 0.5, 0.5, 0.5)
+    EXPECT_NEAR(q3.r, 0.5f, 1e-6f);
+    EXPECT_NEAR(q3.i, 0.5f, 1e-6f);
+    EXPECT_NEAR(q3.j, 0.5f, 1e-6f);
+    EXPECT_NEAR(q3.k, 0.5f, 1e-6f);
 }
 
 TEST(Utils_Quaternion, EulerConversion) {
-    // Test converting Euler angles to quaternion and back
-    vec3 euler(0.5f, 0.6f, 0.7f);
+    vec3 euler(0.5f, 0.6f, 0.7f); // ZYX order assumed by implementation
     quat q;
     q.setEuler(euler);
     vec3 euler2 = q.getEuler();
-    // Allow some tolerance because of potential numerical differences and wrapping.
-    EXPECT_NEAR(euler.x, euler2.x, 1e-3f);
-    EXPECT_NEAR(euler.y, euler2.y, 1e-3f);
-    EXPECT_NEAR(euler.z, euler2.z, 1e-3f);
+
+    // Test near standard range
+    EXPECT_NEAR(euler.x, euler2.x, 1e-6f);
+    EXPECT_NEAR(euler.y, euler2.y, 1e-6f);
+    EXPECT_NEAR(euler.z, euler2.z, 1e-6f);
+
+    // Test gimbal lock case (pitch near +/- 90 degrees)
+    vec3 eulerGimbal(0.5f, M_PI / 2.0f * 0.9999, 0.7f);
+    q.setEuler(eulerGimbal);
+    euler2 = q.getEuler();
+    // In gimbal lock, only the sum/difference of yaw and roll might be preserved
+    // Reconstruct rotation matrix to check equivalence is more robust here,
+    // but let's check if the direct conversion is numerically stable near lock.
+    EXPECT_NEAR(eulerGimbal.x, euler2.x, 1e-3f); // Looser tolerance near gimbal lock
+    EXPECT_NEAR(eulerGimbal.y, euler2.y, 1e-3f);
+    EXPECT_NEAR(eulerGimbal.z, euler2.z, 1e-3f);
+
+    // Test specific angles
+    vec3 euler90Z(0.0f, 0.0f, M_PI / 2.0f);
+    q.setEuler(euler90Z);
+    euler2 = q.getEuler();
+    EXPECT_NEAR(euler90Z.x, euler2.x, 1e-6f);
+    EXPECT_NEAR(euler90Z.y, euler2.y, 1e-6f);
+    EXPECT_NEAR(euler90Z.z, euler2.z, 1e-6f);
 }
 
 TEST(Utils_Quaternion, RotateVector) {
@@ -72,34 +108,45 @@ TEST(Utils_Quaternion, RotateVector) {
     vec3 v(1, 0, 0);
     q.rotateVector(v);
     // The expected rotated vector should be approximately (0, 1, 0)
-    EXPECT_NEAR(v.x, 0.0f, 1e-3f);
-    EXPECT_NEAR(v.y, 1.0f, 1e-3f);
-    EXPECT_NEAR(v.z, 0.0f, 1e-3f);
+    EXPECT_NEAR(v.x, 0.0f, 1e-6f);
+    EXPECT_NEAR(v.y, 1.0f, 1e-6f);
+    EXPECT_NEAR(v.z, 0.0f, 1e-6f);
+
+    // 45-degree rotation about the X axis
+    angle = M_PI / 4.0f;
+    q.setAxisAngle(vec3(1, 0, 0), angle);
+    v = vec3(0, 1, 0);
+    q.rotateVector(v);
+    // Expected: (0, sqrt(2)/2, sqrt(2)/2)
+    EXPECT_NEAR(v.x, 0.0f, 1e-6f);
+    EXPECT_NEAR(v.y, std::sqrt(2.0f) / 2.0f, 1e-6f);
+    EXPECT_NEAR(v.z, std::sqrt(2.0f) / 2.0f, 1e-6f);
 }
 
 TEST(Utils_Quaternion, AxisAngleConversion) {
     // Create a quaternion from an axis-angle representation and then extract the axis and angle.
-    vec3 axis(1, 0, 0);
+    vec3 axis(1, 1, 1);
+    axis.normalize();
     float angle = M_PI / 4.0f; // 45 degrees
     quat q;
     q.setAxisAngle(axis, angle);
     vec3 resAxis;
     float resAngle;
     q.getAxisAngle(resAxis, resAngle);
-    // The axis should be (1,0,0) and the angle should be close to 45 degrees.
-    EXPECT_NEAR(std::abs(resAxis.x), 1.0f, 1e-3f);
-    EXPECT_NEAR(std::abs(resAxis.y), 0.0f, 1e-3f);
-    EXPECT_NEAR(std::abs(resAxis.z), 0.0f, 1e-3f);
+    // The axis direction should be the same and the angle should be close to 45 degrees.
+    EXPECT_NEAR(resAxis.x, axis.x, 1e-3f);
+    EXPECT_NEAR(resAxis.y, axis.y, 1e-3f);
+    EXPECT_NEAR(resAxis.z, axis.z, 1e-3f);
     EXPECT_NEAR(resAngle, angle, 1e-3f);
 }
 
 TEST(Utils_Quaternion, Negation) {
-    quat q(0.5f, 0.5f, 0.5f, 0.5f);
+    quat q(0.5f, 0.1f, -0.2f, 0.8f);
     quat negQ = -q;
-    EXPECT_NEAR(negQ.r, -0.5f, 1e-3f);
-    EXPECT_NEAR(negQ.i, -0.5f, 1e-3f);
-    EXPECT_NEAR(negQ.j, -0.5f, 1e-3f);
-    EXPECT_NEAR(negQ.k, -0.5f, 1e-3f);
+    EXPECT_FLOAT_EQ(negQ.r, -q.r);
+    EXPECT_FLOAT_EQ(negQ.i, -q.i);
+    EXPECT_FLOAT_EQ(negQ.j, -q.j);
+    EXPECT_FLOAT_EQ(negQ.k, -q.k);
 }
 
 TEST(Utils_Quaternion, AddScaledVector) {
@@ -135,28 +182,135 @@ TEST(Utils_Quaternion, TwoDRotation) {
 }
 
 TEST(Utils_Quaternion, RotationFromVectors) {
-    // Define two vectors: rotate from (1,0,0) to (0,1,0)
+    // Case 1: 90 degrees rotation Z-axis
     vec3 before(1.0f, 0.0f, 0.0f);
     vec3 after(0.0f, 1.0f, 0.0f);
     quat q;
     q.setRotationFromVectors(before, after);
 
-    // Expected: rotation of 90 degrees (PI/2) about the Z-axis.
-    float expectedAngle = M_PI / 2.0f;
-    vec3 expectedAxis(0.0f, 0.0f, 1.0f);
-    quat expected;
-    expected.setAxisAngle(expectedAxis, expectedAngle);
+    quat expected_q;
+    expected_q.setAxisAngle(vec3(0.0f, 0.0f, 1.0f), M_PI / 2.0f);
 
-    // Compare the quaternions for equivalence (remember, q and -q represent the same rotation)
-    EXPECT_NEAR(q.r, expected.r, 1e-3f);
-    EXPECT_NEAR(q.i, expected.i, 1e-3f);
-    EXPECT_NEAR(q.j, expected.j, 1e-3f);
-    EXPECT_NEAR(q.k, expected.k, 1e-3f);
+    // Compare quaternions (check absolute dot product == 1 for same rotation)
+    float dot_prod = q.r * expected_q.r + q.i * expected_q.i + q.j * expected_q.j + q.k * expected_q.k;
+    EXPECT_NEAR(std::abs(dot_prod), 1.0f, 1e-6f);
 
-    // Alternatively, compare their rotation matrices:
-    mat3 m1 = q.getRotationMatrix();
-    mat3 m2 = expected.getRotationMatrix();
-    for (int i = 0; i < 9; i++)
-        EXPECT_NEAR(m1.data[i], m2.data[i], 1e-3f);
+    // Case 2: Opposite vectors (180 degrees rotation)
+    before = vec3(1.0f, 0.0f, 0.0f);
+    after = vec3(-1.0f, 0.0f, 0.0f);
+    q.setRotationFromVectors(before, after);
+    // Rotation should be 180 degrees around *any* axis perpendicular to 'before'.
+    // Implementation chooses one based on cross product logic.
+    // Let's test by rotating 'before' and see if we get 'after'.
+    vec3 rotated_before = before;
+    q.rotateVector(rotated_before);
+    EXPECT_NEAR(rotated_before.x, after.x, 1e-6f);
+    EXPECT_NEAR(rotated_before.y, after.y, 1e-6f);
+    EXPECT_NEAR(rotated_before.z, after.z, 1e-6f);
+    // Also check angle is PI
+    vec3 axis;
+    float angle;
+    q.getAxisAngle(axis, angle);
+    EXPECT_NEAR(angle, M_PI, 1e-6f);
+
+    // Case 3: Same vectors (identity rotation)
+    before = vec3(0.0f, 1.0f, 0.0f);
+    after = vec3(0.0f, 1.0f, 0.0f);
+    q.setRotationFromVectors(before, after);
+    // Should result in identity quat (or stay as default identity)
+    EXPECT_NEAR(q.r, 1.0f, 1e-6f);
+    EXPECT_NEAR(q.i, 0.0f, 1e-6f);
+    EXPECT_NEAR(q.j, 0.0f, 1e-6f);
+    EXPECT_NEAR(q.k, 0.0f, 1e-6f);
 }
+
+TEST(Utils_Quaternion, SetRotationMatrix) {
+    const float tolerance = 1e-6f;
+
+    // Test Case 1: Identity Matrix
+    mat3 identity_matrix; // Assuming default constructor gives identity or set manually
+    identity_matrix.mat[0][0] = 1;
+    identity_matrix.mat[0][1] = 0;
+    identity_matrix.mat[0][2] = 0;
+    identity_matrix.mat[1][0] = 0;
+    identity_matrix.mat[1][1] = 1;
+    identity_matrix.mat[1][2] = 0;
+    identity_matrix.mat[2][0] = 0;
+    identity_matrix.mat[2][1] = 0;
+    identity_matrix.mat[2][2] = 1;
+
+    quat q_identity;
+    q_identity.setRotationMatrix(identity_matrix);
+
+    EXPECT_NEAR(q_identity.r, 1.0f, tolerance);
+    EXPECT_NEAR(q_identity.i, 0.0f, tolerance);
+    EXPECT_NEAR(q_identity.j, 0.0f, tolerance);
+    EXPECT_NEAR(q_identity.k, 0.0f, tolerance);
+
+    // Test Case 2: 90 degrees rotation around Z axis
+    quat ref_quat_z90;
+    ref_quat_z90.setAxisAngle(vec3(0, 0, 1), M_PI / 2.0f);
+    mat3 matrix_z90 = ref_quat_z90.getRotationMatrix();
+
+    quat test_quat_z90;
+    test_quat_z90.setRotationMatrix(matrix_z90);
+
+    // Check resulting quaternion components are close to reference (or its negative)
+    float dot_z90 =
+        ref_quat_z90.r * test_quat_z90.r + ref_quat_z90.i * test_quat_z90.i + ref_quat_z90.j * test_quat_z90.j + ref_quat_z90.k * test_quat_z90.k;
+    EXPECT_NEAR(std::abs(dot_z90), 1.0f, tolerance);
+
+    // Check round trip: matrix -> quat -> matrix
+    mat3 result_matrix_z90 = test_quat_z90.getRotationMatrix();
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            EXPECT_NEAR(matrix_z90.mat[i][j], result_matrix_z90.mat[i][j], tolerance);
+        }
+    }
+
+    // Test Case 3: 45 degrees rotation around X axis
+    quat ref_quat_x45;
+    ref_quat_x45.setAxisAngle(vec3(1, 0, 0), M_PI / 4.0f);
+    mat3 matrix_x45 = ref_quat_x45.getRotationMatrix();
+
+    quat test_quat_x45;
+    test_quat_x45.setRotationMatrix(matrix_x45);
+
+    // Check resulting quaternion components are close to reference (or its negative)
+    float dot_x45 =
+        ref_quat_x45.r * test_quat_x45.r + ref_quat_x45.i * test_quat_x45.i + ref_quat_x45.j * test_quat_x45.j + ref_quat_x45.k * test_quat_x45.k;
+    EXPECT_NEAR(std::abs(dot_x45), 1.0f, tolerance);
+
+    // Check round trip: matrix -> quat -> matrix
+    mat3 result_matrix_x45 = test_quat_x45.getRotationMatrix();
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            EXPECT_NEAR(matrix_x45.mat[i][j], result_matrix_x45.mat[i][j], tolerance);
+        }
+    }
+
+    // Test Case 4: Arbitrary rotation (derived from Euler to hit different code paths)
+    // Use Euler angles that don't result in simple trace > 0 or diagonal dominance
+    vec3 euler_arb(1.0f, -2.0f, 0.5f); // Example angles in radians
+    quat ref_quat_arb;
+    ref_quat_arb.setEuler(euler_arb);
+    mat3 matrix_arb = ref_quat_arb.getRotationMatrix();
+
+    quat test_quat_arb;
+    test_quat_arb.setRotationMatrix(matrix_arb);
+
+    // Check resulting quaternion components are close to reference (or its negative)
+    float dot_arb =
+        ref_quat_arb.r * test_quat_arb.r + ref_quat_arb.i * test_quat_arb.i + ref_quat_arb.j * test_quat_arb.j + ref_quat_arb.k * test_quat_arb.k;
+    EXPECT_NEAR(std::abs(dot_arb), 1.0f, tolerance);
+
+    // Check round trip: matrix -> quat -> matrix
+    mat3 result_matrix_arb = test_quat_arb.getRotationMatrix();
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            EXPECT_NEAR(matrix_arb.mat[i][j], result_matrix_arb.mat[i][j], tolerance);
+        }
+    }
+}
+
 } // namespace

--- a/src/extern/solveAssimp.cmake
+++ b/src/extern/solveAssimp.cmake
@@ -39,6 +39,9 @@ set(ATTA_ASSIMP_TARGETS "")
     atta_add_include_dirs(${FETCHCONTENT_BASE_DIR}/assimp-build/include)
     atta_add_libs(assimp)
 
+    # Also make assimp available in the atta namespace
+    add_library(atta::assimp ALIAS assimp)
+
     atta_log(Success Extern "Assimp support (source)")
     set(ATTA_ASSIMP_SUPPORT TRUE)
     set(ATTA_ASSIMP_TARGETS assimp)

--- a/src/extern/solveImgui.cmake
+++ b/src/extern/solveImgui.cmake
@@ -42,6 +42,9 @@ endif()
 atta_add_include_dirs(${FETCHCONTENT_BASE_DIR}/imgui-src)
 atta_add_libs(imgui)
 
+# Also make imgui available in the atta namespace
+add_library(atta::imgui ALIAS imgui)
+
 atta_log(Success Extern "ImGui support (source)")
 set(ATTA_IMGUI_SUPPORT TRUE)
 set(ATTA_IMGUI_TARGETS imgui)

--- a/src/extern/solveImplot.cmake
+++ b/src/extern/solveImplot.cmake
@@ -29,6 +29,9 @@ target_link_libraries(implot PRIVATE glfw imgui)
 atta_add_include_dirs(${FETCHCONTENT_BASE_DIR}/implot-src)
 atta_add_libs(implot)
 
+# Also make implot available in the atta namespace
+add_library(atta::implot ALIAS implot)
+
 atta_log(Success Extern "ImPlot support (source)")
 set(ATTA_IMPLOT_SUPPORT TRUE)
 set(ATTA_IMPLOT_TARGETS implot)

--- a/src/extern/solveImplot3d.cmake
+++ b/src/extern/solveImplot3d.cmake
@@ -30,6 +30,6 @@ target_link_libraries(implot3d PRIVATE glfw imgui)
 atta_add_include_dirs(${FETCHCONTENT_BASE_DIR}/implot3d-src)
 atta_add_libs(implot3d)
 
-atta_log(Success Extern "ImPlot support (source)")
+atta_log(Success Extern "ImPlot3D support (source)")
 set(ATTA_IMPLOT3D_SUPPORT TRUE)
 set(ATTA_IMPLOT3D_TARGETS implot3d)

--- a/src/extern/solveImplot3d.cmake
+++ b/src/extern/solveImplot3d.cmake
@@ -30,6 +30,9 @@ target_link_libraries(implot3d PRIVATE glfw imgui)
 atta_add_include_dirs(${FETCHCONTENT_BASE_DIR}/implot3d-src)
 atta_add_libs(implot3d)
 
+# Also make implot3d available in the atta namespace
+add_library(atta::implot3d ALIAS implot3d)
+
 atta_log(Success Extern "ImPlot3D support (source)")
 set(ATTA_IMPLOT3D_SUPPORT TRUE)
 set(ATTA_IMPLOT3D_TARGETS implot3d)


### PR DESCRIPTION
# Transformation fixes

<p align="center">
<img src="https://github.com/user-attachments/assets/63593efc-4e2d-42c7-8756-ce56c92e9ec7" height="300"/>
</p>

This PR addresses several critical bugs related to transformations and physics within Atta, primarily discovered while developing a more complex drone control simulation project. It also introduces key features for better physics interaction and refines the developer experience.

The core issues revolved around incorrect world transform calculations, especially for nested entities, leading to unpredictable positioning and orientation. Additionally, several inaccuracies in quaternion math and physics state synchronization were identified and resolved.

## 🔧 Changelog
 - **Feat**
   - Targets for libraries built by Atta are now prefixed with `atta::`. The following targets can be linked to a project script when needed: `atta::implot`/`atta::implot3d`/`atta::imgui`/`atta::assimp`
   -  Apply force/torque/velocity to bullet rigid body
   - Ensure `cmp::RigidBody` and `btRigidBody` are in sync
   - `invert` and `inverted` methods for matrices/quaternions
   - Added `wrapRadians` and `wrapDegrees` to `utils/math/common.h`
 - **Refactor**
   - Remove `constraints` from `cmp::RigidBody`
   - Simplify Gizmo UI widget transformation computation
 - **Test**
   - Quaternion class
   - Matrix classes
 - **Fix**
   - `cmp::BoxCollider`, `cmp::SphereCollider`, `cmp::CylinderCollider`, `cmp::BoxCollider2D`, `cmp::CircleCollider2D`, `cmp::RigidBody`, `cmp::RigidBody2D` not saved to `.atta` correctly
   - Wrong world transform computation
   - Wrong transformation of nested entities
   - First build crash when resources downloaded by cmake
   - Wrong quaternion rotate vector
   - Wrong quaternion from 2D angle
   - Wrong quaternion conversion between atta and bullet3