### PR TITLE
Fix world transform computation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(atta VERSION 0.3.9 LANGUAGES CXX C)
+project(atta VERSION 0.3.10 LANGUAGES CXX C)
 
 option(ATTA_BUILD_TESTS "Set to ON to build also the test executables" ON)
 option(ATTA_BUILD_DOCS "Build the documentation" OFF)

--- a/src/atta/component/components/transform.cpp
+++ b/src/atta/component/components/transform.cpp
@@ -39,14 +39,26 @@ Transform Transform::getWorldTransform(EntityId entity) {
 void Transform::setWorldTransform(EntityId entity, Transform worldTransform) {
     (*this) = worldTransform;
 
-    // Go up the hierarchy until root to calculate world to local transform
-    // TODO maybe need to go top down instead
+    // Convert world transform to local transform by removing all parent transformations.
+    // This transformation needs to be applied from the top-most entity to the current entity
+
+    // Build the stack to store hierarchy from top-most entity to the current entity
+    std::stack<EntityId> parentStack;
     Relationship* relationship = component::getComponent<Relationship>(entity);
     while (relationship && relationship->getParent() >= 0) {
-        Transform* ptransform = component::getComponent<Transform>(relationship->getParent());
+        parentStack.push(relationship->getParent());
+        relationship = component::getComponent<Relationship>(relationship->getParent());
+    }
+
+    // Apply the transformations from the top-most entity to the current entity
+    while (!parentStack.empty()) {
+        EntityId parent = parentStack.top();
+        parentStack.pop();
+
+        // Apply the inverse transformation of the parent
+        Transform* ptransform = component::getComponent<Transform>(parent);
         if (ptransform)
             (*this) = (*this) / *ptransform;
-        relationship = component::getComponent<Relationship>(relationship->getParent());
     }
 }
 
@@ -97,7 +109,7 @@ Transform Transform::operator*(const Transform& o) const {
 
 Transform Transform::operator/(const Transform& o) const {
     // Local = world / parent
-    quat oriConj = inverse(o.orientation);
+    quat oriConj = o.orientation.normalized().inverted();
 
     Transform local;
     local.position = oriConj * (position - o.position) / o.scale;

--- a/src/atta/pch.h
+++ b/src/atta/pch.h
@@ -23,6 +23,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <queue>
 #include <set>
 #include <sstream>
 #include <stack>

--- a/src/atta/ui/widgets/gizmo.cpp
+++ b/src/atta/ui/widgets/gizmo.cpp
@@ -40,7 +40,7 @@ bool Gizmo::manipulate(cmp::EntityId entity) {
     std::shared_ptr<Viewport> viewport = _viewport.lock();
     cmp::Transform* t = cmp::getComponent<cmp::Transform>(entity);
     if (viewport && t) {
-        mat4 transform = transpose(t->getWorldTransformMatrix(entity));
+        mat4 transform = t->getWorldTransformMatrix(entity).transposed();
 
         ImGuizmo::SetOrthographic(viewport->getCamera()->getName() == "OrthographicCamera");
         ImGuizmo::SetDrawlist();


### PR DESCRIPTION
There was a bug in the `cmp::Transform` component. The conversion from local transform to world transform was being performed from the leaf node to the root node instead of root node to leaf node, which resulted in wrong world transformation matrices when trying to move/rotate nested nodes with the Gizmo.

Before:

https://github.com/user-attachments/assets/d760c26f-9cb4-47cd-a91c-798a01578bf1

After:

https://github.com/user-attachments/assets/70f3309b-c094-4233-a481-5aab83a37ee5
