### PR TITLE
Chore: Add clang-format check workflow

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -6,7 +6,7 @@ on:
       - dev
     paths:
       - 'src/atta/**/*.{h,cpp,inl}'
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 jobs:
   format-check:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,26 @@
+name: 📝 Check clang-format
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'src/atta/**/*.{h,cpp,inl}'
+  workflow_dispatch: {}
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Check clang-format
+        run: |
+          find src/atta/ -type f \( -name "*.h" -o -name "*.cpp" -o -name "*.inl" \) -exec clang-format --dry-run --Werror {} +

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,4 +1,4 @@
-name: 📝 Check clang-format
+name: 🕵 Check clang-format
 
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 /CMakeSettings.json
 
 # Vim
-tags
+codecompanion*.json
 
 # Local config
 /src/atta/cmakeConfig.h

--- a/src/atta/component/base.h
+++ b/src/atta/component/base.h
@@ -15,7 +15,7 @@ namespace atta::component {
 #define COMPONENT_POOL_SID_BY_NAME(typeidTname) SID((std::string("Component_") + typeidTname + "Allocator").c_str())
 #define COMPONENT_POOL_SSID_BY_NAME(typeidTname) SSID((std::string("Component_") + typeidTname + "Allocator").c_str())
 
-using EntityId = int32_t;           // Index inside entity pool
+using EntityId = int32_t;       // Index inside entity pool
 using ComponentId = StringHash; // Component allocator name hash (COMPONENT_POOL_SID(T) result)
 
 enum class AttributeType {
@@ -75,7 +75,7 @@ struct AttributeDescription {
     std::any min;
     std::any max;
     float step;
-    std::vector<std::string> options;// Enum options
+    std::vector<std::string> options; // Enum options
 };
 
 // FIXME Sometimes crashing when trying to delete the description


### PR DESCRIPTION
# Chore: Add clang-format Check Workflow

Closes #123

This PR introduces a new GitHub Actions workflow to automatically check C++ code formatting using `clang-format`. This ensures that all code merged into the `dev` branch adheres to the project's defined coding style, improving consistency and readability.

The workflow (`.github/workflows/format-check.yml`) triggers on pull requests targeting `dev` whenever `.h`, `.cpp`, or `.inl` files within `src/atta/` are modified. It runs `clang-format --dry-run --Werror`, which will cause the check to fail if any formatting inconsistencies are detected.

This initial commit adds the workflow configuration. Subsequent commits within this PR will address any existing formatting errors identified by `clang-format` to bring the current codebase into compliance.

Additionally, the `.gitignore` file has been updated to ignore `codecompanion*.json` files.

## 🔧 Changelog
 - **Feat**
    - Added GitHub Actions workflow to check C++ code formatting using `clang-format`.
 - **Chore**
    - Updated `.gitignore` to ignore `codecompanion*.json` files.
