### PR TITLE
Style: Apply clang-format

### DIFF
--- a/src/atta/component/components/boxCollider.h
+++ b/src/atta/component/components/boxCollider.h
@@ -14,7 +14,7 @@ namespace atta::component {
 /// %Component to create a box collider
 /** This collider can be used with 3D physics.
  *
- * Transform and RigidBody components are necessary 
+ * Transform and RigidBody components are necessary
  * for the entity to participate in the physics iteration.
  *
  * The box will also be scaled by the Transform scale.

--- a/src/atta/component/entity.cpp
+++ b/src/atta/component/entity.cpp
@@ -19,7 +19,7 @@ bool Entity::exists() const { return _id >= 0; }
 EntityId Entity::getId() const { return _id; }
 
 bool Entity::isPrototype() const {
-    if(get<component::Prototype>())
+    if (get<component::Prototype>())
         return true;
 
     Entity p = getParent();

--- a/src/atta/graphics/apis/vulkan/framebuffer.h
+++ b/src/atta/graphics/apis/vulkan/framebuffer.h
@@ -9,8 +9,8 @@
 
 #include <atta/graphics/apis/vulkan/common.h>
 #include <atta/graphics/apis/vulkan/device.h>
-#include <atta/graphics/apis/vulkan/renderPass.h>
 #include <atta/graphics/apis/vulkan/image.h>
+#include <atta/graphics/apis/vulkan/renderPass.h>
 #include <atta/graphics/framebuffer.h>
 
 namespace atta::graphics::vk {

--- a/src/atta/graphics/apis/vulkan/shader.cpp
+++ b/src/atta/graphics/apis/vulkan/shader.cpp
@@ -8,8 +8,8 @@
 #include <atta/graphics/interface.h>
 
 #include <atta/file/manager.h>
-#include <shaderc/shaderc.hpp>
 #include <regex>
+#include <shaderc/shaderc.hpp>
 
 namespace atta::graphics::vk {
 
@@ -232,9 +232,15 @@ void Shader::compile() {
         // Compute shaderc kind
         shaderc_shader_kind shaderKind;
         switch (type) {
-            case VERTEX: shaderKind = shaderc_vertex_shader; break;
-            case GEOMETRY: shaderKind = shaderc_geometry_shader; break;
-            case FRAGMENT: shaderKind = shaderc_fragment_shader; break;
+            case VERTEX:
+                shaderKind = shaderc_vertex_shader;
+                break;
+            case GEOMETRY:
+                shaderKind = shaderc_geometry_shader;
+                break;
+            case FRAGMENT:
+                shaderKind = shaderc_fragment_shader;
+                break;
             default:
                 LOG_ERROR("gfx::vk::Shader", "Unsupported shader type when compiling [w]$0[]", _file.string());
                 continue;
@@ -243,12 +249,7 @@ void Shader::compile() {
         // Compile shader using shaderc
         shaderc::Compiler compiler;
         shaderc::CompileOptions options;
-        shaderc::CompilationResult result = compiler.CompileGlslToSpv(
-            shaderCode.apiCode,
-            shaderKind,
-            in.string().c_str(),
-            options
-        );
+        shaderc::CompilationResult result = compiler.CompileGlslToSpv(shaderCode.apiCode, shaderKind, in.string().c_str(), options);
         if (result.GetCompilationStatus() != shaderc_compilation_status_success) {
             LOG_ERROR("gfx::vk::Shader", "Shader compilation failed: $0", result.GetErrorMessage());
             continue;

--- a/src/atta/graphics/apis/vulkan/swapChain.h
+++ b/src/atta/graphics/apis/vulkan/swapChain.h
@@ -9,8 +9,8 @@
 
 #include <atta/graphics/apis/vulkan/common.h>
 #include <atta/graphics/apis/vulkan/device.h>
-#include <atta/graphics/apis/vulkan/surface.h>
 #include <atta/graphics/apis/vulkan/image.h>
+#include <atta/graphics/apis/vulkan/surface.h>
 
 namespace atta::graphics::vk {
 

--- a/src/atta/graphics/windows/glfwWindow.h
+++ b/src/atta/graphics/windows/glfwWindow.h
@@ -6,7 +6,7 @@
 //--------------------------------------------------
 #ifndef ATTA_GRAPHICS_WINDOWS_GLFW_WINDOW_H
 #define ATTA_GRAPHICS_WINDOWS_GLFW_WINDOW_H
-//#if defined(ATTA_OS_LINUX) || defined(ATTA_OS_MACOS) || defined(ATTA_OS_WINDOWS)
+// #if defined(ATTA_OS_LINUX) || defined(ATTA_OS_MACOS) || defined(ATTA_OS_WINDOWS)
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
@@ -31,5 +31,5 @@ class GlfwWindow final : public Window {
 
 } // namespace atta::graphics
 
-//#endif// ATTA_OS_XXX
+// #endif// ATTA_OS_XXX
 #endif // ATTA_GRAPHICS_WINDOWS_GLFW_WINDOW_H

--- a/src/atta/io/http/json.cpp
+++ b/src/atta/io/http/json.cpp
@@ -26,56 +26,56 @@ bool ignoreSpaces(const std::string& str, unsigned& pos) {
 std::string Json::dump() {
     std::string result;
     switch (_type) {
-    case NONE: {
-        result = "null";
-        break;
-    }
-    case BOOL: {
-        result = _value.b ? "true" : "false";
-        break;
-    }
-    case INT: {
-        result = std::to_string(_value.i);
-        break;
-    }
-    case FLOAT: {
-        result = std::to_string(_value.f);
-        break;
-    }
-    case STRING: {
-        std::vector<char> str;
-        str.push_back('"');
-        for (char c : _string) {
-            if (c == '"')
-                str.push_back('\\');
-            str.push_back(c);
+        case NONE: {
+            result = "null";
+            break;
         }
-        str.push_back('"');
-        result = std::string(str.begin(), str.end());
-        break;
-    }
-    case VECTOR: {
-        result += "[";
-        for (unsigned i = 0; i < _vector.size(); i++) {
-            result += _vector[i].dump();
-            if (i < _vector.size() - 1)
-                result += ", ";
+        case BOOL: {
+            result = _value.b ? "true" : "false";
+            break;
         }
-        result += "]";
-        break;
-    }
-    case MAP: {
-        result += "{";
-        unsigned i = 0;
-        for (auto& [key, value] : _map) {
-            result += "\"" + key + "\": ";
-            result += value.dump();
-            if (i++ < _map.size() - 1)
-                result += ", ";
+        case INT: {
+            result = std::to_string(_value.i);
+            break;
         }
-        result += "}";
-        break;
-    }
+        case FLOAT: {
+            result = std::to_string(_value.f);
+            break;
+        }
+        case STRING: {
+            std::vector<char> str;
+            str.push_back('"');
+            for (char c : _string) {
+                if (c == '"')
+                    str.push_back('\\');
+                str.push_back(c);
+            }
+            str.push_back('"');
+            result = std::string(str.begin(), str.end());
+            break;
+        }
+        case VECTOR: {
+            result += "[";
+            for (unsigned i = 0; i < _vector.size(); i++) {
+                result += _vector[i].dump();
+                if (i < _vector.size() - 1)
+                    result += ", ";
+            }
+            result += "]";
+            break;
+        }
+        case MAP: {
+            result += "{";
+            unsigned i = 0;
+            for (auto& [key, value] : _map) {
+                result += "\"" + key + "\": ";
+                result += value.dump();
+                if (i++ < _map.size() - 1)
+                    result += ", ";
+            }
+            result += "}";
+            break;
+        }
     }
     return result;
 }

--- a/src/atta/physics/interface.cpp
+++ b/src/atta/physics/interface.cpp
@@ -31,9 +31,7 @@ void setShowJoints(bool showJoints) { Manager::getInstance()._showJoints = showJ
 
 //---------- Queries ----------//
 std::vector<component::EntityId> getEntityCollisions(component::EntityId eid) { return Manager::getInstance()._engine->getEntityCollisions(eid); }
-std::vector<RayCastHit> rayCast(vec3 begin, vec3 end, bool onlyFirst) {
-    return Manager::getInstance()._engine->rayCast(begin, end, onlyFirst);
-}
+std::vector<RayCastHit> rayCast(vec3 begin, vec3 end, bool onlyFirst) { return Manager::getInstance()._engine->rayCast(begin, end, onlyFirst); }
 bool areColliding(component::EntityId eid0, component::EntityId eid1) { return Manager::getInstance()._engine->areColliding(eid0, eid1); }
 
 } // namespace atta::physics

--- a/src/atta/script/compilers/compiler.cpp
+++ b/src/atta/script/compilers/compiler.cpp
@@ -38,7 +38,7 @@ std::vector<fs::path> Compiler::getIncludedFiles(fs::path file) {
                 // If found #include, get file name
                 size_t posBegin = line.find('"') != std::string::npos ? line.find('"') : line.find('<');
                 if (posBegin != std::string::npos) {
-                    size_t posEnd = line.find('"', posBegin+1) != std::string::npos ? line.find('"', posBegin+1) : line.find('>', posBegin+1);
+                    size_t posEnd = line.find('"', posBegin + 1) != std::string::npos ? line.find('"', posBegin + 1) : line.find('>', posBegin + 1);
                     if (posEnd != std::string::npos) {
                         std::string possibleFile = line.substr(posBegin + 1, posEnd - posBegin - 1);
                         for (auto base : possibleBases) {

--- a/src/atta/script/compilers/linuxCompiler.cpp
+++ b/src/atta/script/compilers/linuxCompiler.cpp
@@ -177,15 +177,14 @@ void LinuxCompiler::findTargetFiles(StringId target) {
 
     // Get all files that where included
     std::set<fs::path> targetFiles(cmakeTargetFiles.begin(), cmakeTargetFiles.end());
-    for(fs::path file : cmakeTargetFiles)
-    {
+    for (fs::path file : cmakeTargetFiles) {
         std::vector<fs::path> includedFiles = getIncludedFiles(file);
         targetFiles.insert(includedFiles.begin(), includedFiles.end());
     }
 
     // Update files related to this target
     _targetFiles[target] = {};
-    for(fs::path file : targetFiles)
+    for (fs::path file : targetFiles)
         _targetFiles[target].push_back(file);
 }
 

--- a/src/atta/script/compilers/nullCompiler.h
+++ b/src/atta/script/compilers/nullCompiler.h
@@ -15,8 +15,8 @@ class NullCompiler : public Compiler {
   public:
     NullCompiler() = default;
 
-    void compileAll() override {};
-    void compileTarget(StringId target) override {};
+    void compileAll() override {}
+    void compileTarget(StringId target) override {}
 };
 
 } // namespace atta::script

--- a/src/atta/script/compilers/nullCompiler.h
+++ b/src/atta/script/compilers/nullCompiler.h
@@ -15,8 +15,8 @@ class NullCompiler : public Compiler {
   public:
     NullCompiler() = default;
 
-    void compileAll() override{};
-    void compileTarget(StringId target) override{};
+    void compileAll() override {};
+    void compileTarget(StringId target) override {};
 };
 
 } // namespace atta::script

--- a/src/atta/script/linkers/linuxLinker.cpp
+++ b/src/atta/script/linkers/linuxLinker.cpp
@@ -27,17 +27,16 @@ void LinuxLinker::linkTarget(StringId target, Script** script, ProjectScript** p
     fs::path libCpyDir = projectDir / "build" / "atta" / "script" / target.getString();
 
     // Keep some of the last library versions (segfault if library still in use)
-    if (fs::exists(libCpyDir))
-    {
+    if (fs::exists(libCpyDir)) {
         // Get files
         std::vector<std::string> files;
-        for(auto entry : fs::directory_iterator(libCpyDir))
+        for (auto entry : fs::directory_iterator(libCpyDir))
             files.push_back(entry.path().string());
 
         std::sort(files.begin(), files.end());
         // Keep up to 10 old files (should be only one)
-        if(files.size())
-            for(int i = 0; i < int(files.size())-10; i++)
+        if (files.size())
+            for (int i = 0; i < int(files.size()) - 10; i++)
                 fs::remove(files[i]);
     }
     fs::create_directories(libCpyDir);

--- a/src/atta/script/linkers/nullLinker.h
+++ b/src/atta/script/linkers/nullLinker.h
@@ -16,7 +16,7 @@ class NullLinker : public Linker {
     ~NullLinker() = default;
 
     void linkTarget(StringId target, Script** script, ProjectScript** projectScript, std::string& name) override;
-    virtual void releaseTarget(StringId target) override {};
+    virtual void releaseTarget(StringId target) override {}
 };
 
 } // namespace atta::script

--- a/src/atta/script/linkers/nullLinker.h
+++ b/src/atta/script/linkers/nullLinker.h
@@ -16,7 +16,7 @@ class NullLinker : public Linker {
     ~NullLinker() = default;
 
     void linkTarget(StringId target, Script** script, ProjectScript** projectScript, std::string& name) override;
-    virtual void releaseTarget(StringId target) override{};
+    virtual void releaseTarget(StringId target) override {};
 };
 
 } // namespace atta::script

--- a/src/atta/script/managerStatic.cpp
+++ b/src/atta/script/managerStatic.cpp
@@ -4,8 +4,8 @@
 // Date: 2022-06-12
 // By Breno Cunha Queiroz
 //--------------------------------------------------
-#include <atta/script/scripts.h>
 #include <atta/event/events/projectOpen.h>
+#include <atta/script/scripts.h>
 
 namespace atta::script {
 

--- a/src/atta/script/projectScript.h
+++ b/src/atta/script/projectScript.h
@@ -12,27 +12,27 @@ namespace atta::script {
 class ProjectScript {
   public:
     ProjectScript() = default;
-    virtual ~ProjectScript() {};
+    virtual ~ProjectScript() {}
 
     //---------- Load/Unload ----------//
-    virtual void onLoad() {};
-    virtual void onUnload() {};
+    virtual void onLoad() {}
+    virtual void onUnload() {}
 
     //---------- Simulation ----------//
-    virtual void onStart() {};
-    virtual void onStop() {};
+    virtual void onStart() {}
+    virtual void onStop() {}
 
-    virtual void onContinue() {};
-    virtual void onPause() {};
+    virtual void onContinue() {}
+    virtual void onPause() {}
 
-    virtual void onUpdateBefore(float delta) {};
-    virtual void onUpdateAfter(float delta) {};
+    virtual void onUpdateBefore(float delta) {}
+    virtual void onUpdateAfter(float delta) {}
 
     //---------- Editor ----------//
-    virtual void onUIRender() {};
+    virtual void onUIRender() {}
 
     //---------- While ----------//
-    virtual void onAttaLoop() {};
+    virtual void onAttaLoop() {}
 };
 } // namespace atta::script
 

--- a/src/atta/script/projectScript.h
+++ b/src/atta/script/projectScript.h
@@ -12,27 +12,27 @@ namespace atta::script {
 class ProjectScript {
   public:
     ProjectScript() = default;
-    virtual ~ProjectScript(){};
+    virtual ~ProjectScript() {};
 
     //---------- Load/Unload ----------//
-    virtual void onLoad(){};
-    virtual void onUnload(){};
+    virtual void onLoad() {};
+    virtual void onUnload() {};
 
     //---------- Simulation ----------//
-    virtual void onStart(){};
-    virtual void onStop(){};
+    virtual void onStart() {};
+    virtual void onStop() {};
 
-    virtual void onContinue(){};
-    virtual void onPause(){};
+    virtual void onContinue() {};
+    virtual void onPause() {};
 
-    virtual void onUpdateBefore(float delta){};
-    virtual void onUpdateAfter(float delta){};
+    virtual void onUpdateBefore(float delta) {};
+    virtual void onUpdateAfter(float delta) {};
 
     //---------- Editor ----------//
-    virtual void onUIRender(){};
+    virtual void onUIRender() {};
 
     //---------- While ----------//
-    virtual void onAttaLoop(){};
+    virtual void onAttaLoop() {};
 };
 } // namespace atta::script
 

--- a/src/atta/script/script.h
+++ b/src/atta/script/script.h
@@ -13,7 +13,7 @@ namespace atta::script {
 class Script {
   public:
     Script() = default;
-    virtual ~Script() {};
+    virtual ~Script() {}
     virtual void update(component::Entity entity, float dt) = 0;
 };
 

--- a/src/atta/sensor/managerInfrared.cpp
+++ b/src/atta/sensor/managerInfrared.cpp
@@ -88,7 +88,7 @@ void Manager::updateInfrareds(float dt) {
             vec3 begin = worldTrans.position;
             vec3 end = begin + rayDir * ir->upperLimit;
             std::vector<phy::RayCastHit> hits = phy::rayCast(begin, end, true);
-            if(hits.size())
+            if (hits.size())
                 measurement = hits[0].distance;
             else
                 measurement = ir->upperLimit;

--- a/src/atta/ui/widgets/button.cpp
+++ b/src/atta/ui/widgets/button.cpp
@@ -11,6 +11,8 @@
 
 namespace atta::ui {
 
-bool imageButton(std::string name, float size) { return ImGui::ImageButton(name.c_str(), (ImTextureID)(intptr_t)gfx::getImGuiImage(name), ImVec2(size, size)); }
+bool imageButton(std::string name, float size) {
+    return ImGui::ImageButton(name.c_str(), (ImTextureID)(intptr_t)gfx::getImGuiImage(name), ImVec2(size, size));
+}
 
 } // namespace atta::ui

--- a/src/atta/ui/widgets/image.h
+++ b/src/atta/ui/widgets/image.h
@@ -13,4 +13,4 @@ void image(std::string name, vec2 size);
 
 } // namespace atta::ui
 
-#endif// ATTA_UI_WIDGETS_IMAGE_H
+#endif // ATTA_UI_WIDGETS_IMAGE_H

--- a/src/atta/ui/windows/physicsModuleWindow.cpp
+++ b/src/atta/ui/windows/physicsModuleWindow.cpp
@@ -27,7 +27,6 @@ void PhysicsModuleWindow::renderImpl() {
             if (ImGui::Selectable(physicsEngines[i].c_str(), i == selected)) {
                 selected = (physics::Engine::Type)i;
                 physics::setEngineType(selected);
-
             }
             if (i == selected)
                 ImGui::SetItemDefaultFocus();
@@ -96,9 +95,9 @@ void PhysicsModuleWindow::renderImpl() {
             // Number of collisions
             unsigned numCollisions2 = 0;
             auto collisions = bullet->getCollisions();
-            for(auto [bodyA, bodiesB] : collisions)
+            for (auto [bodyA, bodiesB] : collisions)
                 numCollisions2 += bodiesB.size();
-            ImGui::Text("Num collisions: %u", numCollisions2/2);
+            ImGui::Text("Num collisions: %u", numCollisions2 / 2);
             break;
         }
     }

--- a/src/atta/ui/windows/timeProfiler/components/tearDown.h
+++ b/src/atta/ui/windows/timeProfiler/components/tearDown.h
@@ -23,7 +23,7 @@ class TearDown {
         StringId name;
         Profiler::Time time;
     };
-    std::vector<FuncTime> _funcTime; 
+    std::vector<FuncTime> _funcTime;
     size_t _lastRecordsSize;
     bool _exclusive;
 

--- a/src/atta/utils/config.h
+++ b/src/atta/utils/config.h
@@ -33,8 +33,8 @@ class Config final {
     State _state;
 
     //----- Stepping -----//
-    float _dt;    ///< Simulation step in seconds
-    float _time;  ///< Current simulation time
+    float _dt;   ///< Simulation step in seconds
+    float _time; ///< Current simulation time
     /// Desired step speed
     /** Desired speed relative to real time
      * 0.0 = step as fast as possible

--- a/src/atta/utils/math/bounds.h
+++ b/src/atta/utils/math/bounds.h
@@ -7,8 +7,8 @@
 #ifndef ATTA_UTILS_MATH_BOUNDS_H
 #define ATTA_UTILS_MATH_BOUNDS_H
 
-#include <atta/utils/math/vector.h>
 #include <atta/utils/math/ray.h>
+#include <atta/utils/math/vector.h>
 
 namespace atta {
 //---------- Bounds 3 ----------//

--- a/src/atta/utils/profiler.h
+++ b/src/atta/utils/profiler.h
@@ -6,22 +6,22 @@
 //--------------------------------------------------
 #ifndef ATTA_UTILS_PROFILER_H
 #define ATTA_UTILS_PROFILER_H
-#include <chrono>
 #include <atta/utils/stringId.h>
+#include <chrono>
 
 namespace atta {
 
 //---------- Profiler ----------//
 class Profiler {
   public:
-    using Time = uint64_t;///< Time point in ns
-    using ThreadId = uint32_t;///< Thread id
-    static constexpr Time ticksPerSecond = 1000*1000*1000;
+    using Time = uint64_t;     ///< Time point in ns
+    using ThreadId = uint32_t; ///< Thread id
+    static constexpr Time ticksPerSecond = 1000 * 1000 * 1000;
     struct Record {
-        StringId name;///< Function name
-        ThreadId threadId;///< Thread Id
-        Time begin;///< Start time in ns
-        Time end;///< End time in ns
+        StringId name;     ///< Function name
+        ThreadId threadId; ///< Thread Id
+        Time begin;        ///< Start time in ns
+        Time end;          ///< End time in ns
     };
 
     static Profiler& getInstance();
@@ -56,7 +56,6 @@ class Profiler {
     /// Get function name without return type and parameters
     static std::string cropFuncName(std::string name);
 
-
   private:
     Profiler() = default;
 
@@ -68,11 +67,11 @@ class Profiler {
 
 //---------- ProfilerRecord ----------//
 class ProfilerRecord {
-public:
+  public:
     ProfilerRecord(StringId name);
     ~ProfilerRecord();
 
-private:
+  private:
     StringId _name;
     static bool _record;
     std::chrono::time_point<std::chrono::high_resolution_clock> _startTime;

--- a/src/atta/utils/tests/math.cpp
+++ b/src/atta/utils/tests/math.cpp
@@ -479,8 +479,8 @@ TEST(Utils_Math_Vector, TypeDeduction) {
     }
 }
 
-//#include <immintrin.h>
-// TEST(Utils_Math_Vector, SIMD128)
+// #include <immintrin.h>
+//  TEST(Utils_Math_Vector, SIMD128)
 //{
 //	class Vec128
 //	{


### PR DESCRIPTION
# Style: Apply clang-format
<div align="center">
<img src="https://github.com/user-attachments/assets/e58a25b4-30ba-47e0-931c-bb2dcff1553a">
</div>

This PR applies `clang-format` to the codebase to fix formatting inconsistencies identified by the workflow introduced in #[Insert PR Number of the workflow PR here].

All `.h`, `.cpp`, and `.inl` files within `src/atta/` have been formatted according to the project's `.clang-format` configuration. This ensures the codebase adheres to the established coding style.

## 🔧 Changelog
 - **Style**
    - Applied `clang-format` to all C++ source and header files.