### PR TITLE
Chore: Remove `dev` branch

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -3,7 +3,7 @@ name: 🕵 Check clang-format
 on:
   pull_request:
     branches:
-      - dev
+      - main
     paths:
       - 'src/atta/**/*.{h,cpp,inl}'
   workflow_dispatch:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -2,10 +2,6 @@ name: 🕵 Check clang-format
 
 on:
   pull_request:
-    branches:
-      - main
-    paths:
-      - 'src/atta/**/*.{h,cpp,inl}'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -5,7 +5,7 @@ on:
     types:
       - labeled  # Runs when labels are added to the PR
     branches:
-      - dev  # Only run for PRs targeting the dev branch
+      - main  # Only run for PRs targeting the main branch
     if: github.event.pull_request.merged == false  # Skip if PR is already merged
 
 jobs:
@@ -42,12 +42,12 @@ jobs:
             exit 0
           fi
 
-      - name: Merge `dev` into PR Branch
+      - name: Merge `main` into PR Branch
         if: env.run_versioning == 'true'
         run: |
-          git fetch origin dev
+          git fetch origin main
           git checkout ${{ github.head_ref }}
-          if git merge --no-edit origin/dev; then
+          if git merge --no-edit origin/main; then
             echo "Merge successful."
           else
             echo "::error::Merge conflict detected! Resolve conflicts manually."
@@ -55,17 +55,17 @@ jobs:
           fi
         continue-on-error: false
 
-      - name: Get Current Version from `dev`
+      - name: Get Current Version from `main`
         if: env.run_versioning == 'true'
         run: |
-          VERSION=$(git show origin/dev:CMakeLists.txt | sed -nE 's/project\(atta VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+          VERSION=$(git show origin/main:CMakeLists.txt | sed -nE 's/project\(atta VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
 
           if [[ -z "$VERSION" ]]; then
             echo "::error::Failed to extract version from CMakeLists.txt"
             exit 1
           fi
 
-          echo "::notice::Current Version (from dev): $VERSION"
+          echo "::notice::Current Version (from main): $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Determine Version Increment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,14 +59,14 @@ Atta uses the standard Fork & Pull Request workflow.
 
 1.  **Fork the Repository:** Create a fork of the `brenocq/atta` repository to your own GitHub account.
 2.  **Clone Your Fork:** Clone your forked repository locally: `git clone git@github.com:YOUR_USERNAME/atta.git`
-3.  **Create a Branch:** Create a new branch for your changes, based off the `dev` branch: `git checkout dev && git pull origin dev && git checkout -b feat/your-feature-name` (replace `feat/your-feature-name` with a descriptive name).
+3.  **Create a Branch:** Create a new branch for your changes, based off the `main` branch: `git checkout main && git pull origin main && git checkout -b feat/your-feature-name` (replace `feat/your-feature-name` with a descriptive name).
 4.  **Make Changes:** Implement your feature or fix the bug. Ensure your code adheres to the project's [Code Style](#code-style).
 5.  **Commit Changes:** Commit your changes with clear and concise commit messages.
 6.  **Push Branch:** Push your feature branch to your fork: `git push origin feat/your-feature-name`
-7.  **Open a Pull Request:** Go to the `brenocq/atta` repository on GitHub and open a Pull Request comparing your fork's feature branch (`YOUR_USERNAME/atta:feat/your-feature-name`) to the main repository's `dev` branch (`brenocq/atta:dev`).
+7.  **Open a Pull Request:** Go to the `brenocq/atta` repository on GitHub and open a Pull Request comparing your fork's feature branch (`YOUR_USERNAME/atta:feat/your-feature-name`) to the main repository's `main` branch (`brenocq/atta:main`).
 8.  **Link Issue:** In the PR description, link the issue(s) your PR addresses using keywords like `Fixes #123` or `Closes #123`. This helps with tracking and automated status updates.
 9.  **Review Process:** Your PR will be reviewed. Automated checks (like formatting and code analysis) must pass. Be prepared to discuss your changes and make adjustments based on feedback.
-10. **Merging:** Once approved and all checks pass, your PR will be merged into the `dev` branch.
+10. **Merging:** Once approved and all checks pass, your PR will be merged into the `main` branch.
 
 ## Code Style
 


### PR DESCRIPTION
# Chore: Remove `dev` branch

Closes #123

<div align="center">
<img src="https://github.com/user-attachments/assets/861e019a-579e-479a-a739-495d12c1cb5e">
</div>

This PR removes the `dev` branch and transitions Atta to a simpler, mainline development workflow (similar to GitHub Flow).

**Motivation:**

The `dev` branch added an extra step without providing significant advantages for this project's current scale and process. Feature branches created directly from `main` offer sufficient isolation for development and testing, ensuring `main` remains stable and releasable. Simplifying the workflow reduces overhead and makes the contribution process more straightforward.

**Changes:**

* **GitHub Actions:**
    * The `format-check.yml` workflow now triggers on pull requests targeting `main`.
    * The `versioning.yml` workflow now targets `main`, merges `main` into the PR branch for checks, and extracts the current version from `main`.
* **Documentation:**
    * `CONTRIBUTING.md` has been updated to instruct contributors to branch from `main` and open pull requests against `main`.

This change streamlines the development process by removing the intermediate `dev` branch. All new feature work should now branch from `main` and target `main` for pull requests.

## 🔧 Changelog

* **Chore**
    * Updated `format-check.yml` workflow to target the `main` branch.
    * Updated `versioning.yml` workflow to target and operate against the `main` branch.
* **Docs**
    * Updated `CONTRIBUTING.md` to reflect the switch from a `dev`-based workflow to a `main`-based workflow.