### PR TITLE
Chore: Status label workflow

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   format-check:
+    name: Check clang-format
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - closed
+      - reopened # For testing
 
 permissions:
   contents: read
@@ -21,7 +22,8 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set PR status to review
-      if: ${{ github.event.action == 'opened' }}
+      # Reopened event is used for testing
+      if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
       uses: actions/github-script@v6
       with:
         script: |
@@ -99,7 +101,8 @@ jobs:
           }
 
     - name: Set PR and linked issues to done
-      if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true }}
+      # && github.event.pull_request.merged == true (disabled for testing)
+      if: ${{ github.event.action == 'closed'}}
       uses: actions/github-script@v6
       with:
         script: |

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -1,4 +1,4 @@
-name: Update Status Labels
+name: 🛠️ Status Labels
 
 on:
   pull_request:
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   update-labels:
+    name: Update Status Labels
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -35,30 +35,30 @@ jobs:
           }
           console.log(`PR Number: ${prNumber}`);
 
-          // Remove all labels starting with 'status:' from the PR
+          // Remove all labels starting with 'status:' from the PR, except 'status:review'
           const prLabels = context.payload.pull_request.labels || [];
+          let alreadyInReview = false;
           for (const label of prLabels) {
-            if (label.name.startsWith('status:')) {
+            if (label.name === 'status:review') {
+              alreadyInReview = true;
+            } else if (label.name.startsWith('status:')) {
               await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                name: label.name
-              }).catch(() => console.log(`Label ${label.name} not found on PR`));
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              name: label.name
+              });
             }
           }
 
-          // Add 'status:review' label to the PR
-          if (github?.rest?.issues?.addLabels) {
+          // Add 'status:review' label to the PR if not already present
+          if (!alreadyInReview) {
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
               labels: ['status:review']
             });
-            console.log('Added status:review label to PR');
-          } else {
-            console.log('Error: github.rest.issues.addLabels is not available');
           }
 
           // Process linked issues
@@ -82,22 +82,18 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: issueNumber,
                   name: label.name
-                }).catch(() => console.log(`Label ${label.name} not found on issue ${issueNumber}`));
+                });
               }
             }
 
             // Add 'status:review' label to the linked issue
-            if (github?.rest?.issues?.addLabels) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                labels: ['status:review']
-              });
-              console.log(`Added status:review label to issue: ${issueNumber}`);
-            } else {
-              console.log('Error: github.rest.issues.addLabels is not available');
-            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['status:review']
+            });
+            console.log(`Added status:review label to issue: ${issueNumber}`);
           }
 
     - name: Set PR and linked issues to done
@@ -113,44 +109,36 @@ jobs:
             return;
           }
           console.log(`PR Number: ${prNumber}`);
-          if (github?.rest?.issues?.removeLabel && github?.rest?.issues?.addLabels) {
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              name: 'status:review'
-            }).catch(() => console.log('status:review label not found on PR'));
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              labels: ['status:done']
-            });
-            console.log('Added status:done label to PR');
-          } else {
-            console.log('Error: github.rest.issues.removeLabel or github.rest.issues.addLabels is not available');
-          }
+          await github.rest.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            name: 'status:review'
+          }).catch(() => console.log('status:review label not found on PR'));
+          await github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            labels: ['status:done']
+          });
+          console.log('Added status:done label to PR');
 
           const linkedIssues = context.payload.pull_request.body?.match(/(?:Fixes|Closes) #\d+/g) || [];
           console.log(`Linked Issues: ${linkedIssues}`);
           for (const issueRef of linkedIssues) {
             const issueNumber = parseInt(issueRef.split('#')[1]);
             console.log(`Processing linked issue: ${issueNumber}`);
-            if (github?.rest?.issues?.removeLabel && github?.rest?.issues?.addLabels) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                name: 'status:review'
-              }).catch(() => console.log('status:review label not found on issue'));
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                labels: ['status:done']
-              });
-              console.log(`Added status:done label to issue: ${issueNumber}`);
-            } else {
-              console.log('Error: github.rest.issues.removeLabel or github.rest.issues.addLabels is not available');
-            }
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              name: 'status:review'
+            }).catch(() => console.log('status:review label not found on issue'));
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['status:done']
+            });
+            console.log(`Added status:done label to issue: ${issueNumber}`);
           }

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
       - closed
-      - reopened # For testing
 
 permissions:
   contents: read
@@ -22,7 +22,6 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set PR status to review
-      # Reopened event is used for testing
       if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
       uses: actions/github-script@v6
       with:
@@ -109,8 +108,7 @@ jobs:
           }
 
     - name: Set PR and linked issues to done
-      # && github.event.pull_request.merged == true (disabled for testing)
-      if: ${{ github.event.action == 'closed'}}
+      if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true }}
       uses: actions/github-script@v6
       with:
         script: |

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -24,41 +24,47 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
+          console.log('PR opened event triggered');
           const prNumber = context.payload.pull_request.number;
+          console.log(`PR Number: ${prNumber}`);
           await github.issues.addLabels({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: prNumber,
             labels: ['status:review']
           });
+          console.log('Added status:review label to PR');
 
           const linkedIssues = context.payload.pull_request.body.match(/(?:Fixes|Closes) #\d+/g) || [];
+          console.log(`Linked Issues: ${linkedIssues}`);
           for (const issueRef of linkedIssues) {
             const issueNumber = parseInt(issueRef.split('#')[1]);
+            console.log(`Processing linked issue: ${issueNumber}`);
             await github.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               name: 'status:idea'
-            }).catch(() => {});
+            }).catch(() => console.log('status:idea label not found'));
             await github.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               name: 'status:todo'
-            }).catch(() => {});
+            }).catch(() => console.log('status:todo label not found'));
             await github.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               name: 'status:doing'
-            }).catch(() => {});
+            }).catch(() => console.log('status:doing label not found'));
             await github.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               labels: ['status:review']
             });
+            console.log(`Added status:review label to issue: ${issueNumber}`);
           }
 
     - name: Set PR and linked issues to done
@@ -66,33 +72,39 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
+          console.log('PR closed and merged event triggered');
           const prNumber = context.payload.pull_request.number;
+          console.log(`PR Number: ${prNumber}`);
           await github.issues.removeLabel({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: prNumber,
             name: 'status:review'
-          }).catch(() => {});
+          }).catch(() => console.log('status:review label not found on PR'));
           await github.issues.addLabels({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: prNumber,
             labels: ['status:done']
           });
+          console.log('Added status:done label to PR');
 
           const linkedIssues = context.payload.pull_request.body.match(/(?:Fixes|Closes) #\d+/g) || [];
+          console.log(`Linked Issues: ${linkedIssues}`);
           for (const issueRef of linkedIssues) {
             const issueNumber = parseInt(issueRef.split('#')[1]);
+            console.log(`Processing linked issue: ${issueNumber}`);
             await github.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               name: 'status:review'
-            }).catch(() => {});
+            }).catch(() => console.log('status:review label not found on issue'));
             await github.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               labels: ['status:done']
             });
+            console.log(`Added status:done label to issue: ${issueNumber}`);
           }

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -39,7 +39,7 @@ jobs:
           const prLabels = context.payload.pull_request.labels || [];
           for (const label of prLabels) {
             if (label.name.startsWith('status:')) {
-              await github.issues.removeLabel({
+              await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
@@ -49,8 +49,8 @@ jobs:
           }
 
           // Add 'status:review' label to the PR
-          if (github?.issues?.addLabels) {
-            await github.issues.addLabels({
+          if (github?.rest?.issues?.addLabels) {
+            await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
@@ -58,7 +58,7 @@ jobs:
             });
             console.log('Added status:review label to PR');
           } else {
-            console.log('Error: github.issues.addLabels is not available');
+            console.log('Error: github.rest.issues.addLabels is not available');
           }
 
           // Process linked issues
@@ -69,7 +69,7 @@ jobs:
             console.log(`Processing linked issue: ${issueNumber}`);
 
             // Remove all labels starting with 'status:' from the linked issue
-            const issueLabels = (await github.issues.listLabelsOnIssue({
+            const issueLabels = (await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber
@@ -77,7 +77,7 @@ jobs:
 
             for (const label of issueLabels) {
               if (label.name.startsWith('status:')) {
-                await github.issues.removeLabel({
+                await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issueNumber,
@@ -87,8 +87,8 @@ jobs:
             }
 
             // Add 'status:review' label to the linked issue
-            if (github?.issues?.addLabels) {
-              await github.issues.addLabels({
+            if (github?.rest?.issues?.addLabels) {
+              await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
@@ -96,7 +96,7 @@ jobs:
               });
               console.log(`Added status:review label to issue: ${issueNumber}`);
             } else {
-              console.log('Error: github.issues.addLabels is not available');
+              console.log('Error: github.rest.issues.addLabels is not available');
             }
           }
 
@@ -113,14 +113,14 @@ jobs:
             return;
           }
           console.log(`PR Number: ${prNumber}`);
-          if (github?.issues?.removeLabel && github?.issues?.addLabels) {
-            await github.issues.removeLabel({
+          if (github?.rest?.issues?.removeLabel && github?.rest?.issues?.addLabels) {
+            await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
               name: 'status:review'
             }).catch(() => console.log('status:review label not found on PR'));
-            await github.issues.addLabels({
+            await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
@@ -128,7 +128,7 @@ jobs:
             });
             console.log('Added status:done label to PR');
           } else {
-            console.log('Error: github.issues.removeLabel or github.issues.addLabels is not available');
+            console.log('Error: github.rest.issues.removeLabel or github.rest.issues.addLabels is not available');
           }
 
           const linkedIssues = context.payload.pull_request.body?.match(/(?:Fixes|Closes) #\d+/g) || [];
@@ -136,14 +136,14 @@ jobs:
           for (const issueRef of linkedIssues) {
             const issueNumber = parseInt(issueRef.split('#')[1]);
             console.log(`Processing linked issue: ${issueNumber}`);
-            if (github?.issues?.removeLabel && github?.issues?.addLabels) {
-              await github.issues.removeLabel({
+            if (github?.rest?.issues?.removeLabel && github?.rest?.issues?.addLabels) {
+              await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
                 name: 'status:review'
               }).catch(() => console.log('status:review label not found on issue'));
-              await github.issues.addLabels({
+              await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
@@ -151,6 +151,6 @@ jobs:
               });
               console.log(`Added status:done label to issue: ${issueNumber}`);
             } else {
-              console.log('Error: github.issues.removeLabel or github.issues.addLabels is not available');
+              console.log('Error: github.rest.issues.removeLabel or github.rest.issues.addLabels is not available');
             }
           }

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -26,46 +26,76 @@ jobs:
       with:
         script: |
           console.log('PR opened event triggered');
-          const prNumber = context.payload.pull_request.number;
+          const prNumber = context.payload.pull_request?.number;
+          if (!prNumber) {
+            console.log('Error: PR number is undefined');
+            return;
+          }
           console.log(`PR Number: ${prNumber}`);
-          await github.issues.addLabels({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: prNumber,
-            labels: ['status:review']
-          });
-          console.log('Added status:review label to PR');
 
-          const linkedIssues = context.payload.pull_request.body.match(/(?:Fixes|Closes) #\d+/g) || [];
+          // Remove all labels starting with 'status:' from the PR
+          const prLabels = context.payload.pull_request.labels || [];
+          for (const label of prLabels) {
+            if (label.name.startsWith('status:')) {
+              await github.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: label.name
+              }).catch(() => console.log(`Label ${label.name} not found on PR`));
+            }
+          }
+
+          // Add 'status:review' label to the PR
+          if (github?.issues?.addLabels) {
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['status:review']
+            });
+            console.log('Added status:review label to PR');
+          } else {
+            console.log('Error: github.issues.addLabels is not available');
+          }
+
+          // Process linked issues
+          const linkedIssues = context.payload.pull_request.body?.match(/(?:Fixes|Closes) #\d+/g) || [];
           console.log(`Linked Issues: ${linkedIssues}`);
           for (const issueRef of linkedIssues) {
             const issueNumber = parseInt(issueRef.split('#')[1]);
             console.log(`Processing linked issue: ${issueNumber}`);
-            await github.issues.removeLabel({
+
+            // Remove all labels starting with 'status:' from the linked issue
+            const issueLabels = (await github.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: issueNumber,
-              name: 'status:idea'
-            }).catch(() => console.log('status:idea label not found'));
-            await github.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              name: 'status:todo'
-            }).catch(() => console.log('status:todo label not found'));
-            await github.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              name: 'status:doing'
-            }).catch(() => console.log('status:doing label not found'));
-            await github.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              labels: ['status:review']
-            });
-            console.log(`Added status:review label to issue: ${issueNumber}`);
+              issue_number: issueNumber
+            })).data;
+
+            for (const label of issueLabels) {
+              if (label.name.startsWith('status:')) {
+                await github.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label.name
+                }).catch(() => console.log(`Label ${label.name} not found on issue ${issueNumber}`));
+              }
+            }
+
+            // Add 'status:review' label to the linked issue
+            if (github?.issues?.addLabels) {
+              await github.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['status:review']
+              });
+              console.log(`Added status:review label to issue: ${issueNumber}`);
+            } else {
+              console.log('Error: github.issues.addLabels is not available');
+            }
           }
 
     - name: Set PR and linked issues to done
@@ -74,38 +104,50 @@ jobs:
       with:
         script: |
           console.log('PR closed and merged event triggered');
-          const prNumber = context.payload.pull_request.number;
+          const prNumber = context.payload.pull_request?.number;
+          if (!prNumber) {
+            console.log('Error: PR number is undefined');
+            return;
+          }
           console.log(`PR Number: ${prNumber}`);
-          await github.issues.removeLabel({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: prNumber,
-            name: 'status:review'
-          }).catch(() => console.log('status:review label not found on PR'));
-          await github.issues.addLabels({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: prNumber,
-            labels: ['status:done']
-          });
-          console.log('Added status:done label to PR');
+          if (github?.issues?.removeLabel && github?.issues?.addLabels) {
+            await github.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              name: 'status:review'
+            }).catch(() => console.log('status:review label not found on PR'));
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['status:done']
+            });
+            console.log('Added status:done label to PR');
+          } else {
+            console.log('Error: github.issues.removeLabel or github.issues.addLabels is not available');
+          }
 
-          const linkedIssues = context.payload.pull_request.body.match(/(?:Fixes|Closes) #\d+/g) || [];
+          const linkedIssues = context.payload.pull_request.body?.match(/(?:Fixes|Closes) #\d+/g) || [];
           console.log(`Linked Issues: ${linkedIssues}`);
           for (const issueRef of linkedIssues) {
             const issueNumber = parseInt(issueRef.split('#')[1]);
             console.log(`Processing linked issue: ${issueNumber}`);
-            await github.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              name: 'status:review'
-            }).catch(() => console.log('status:review label not found on issue'));
-            await github.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              labels: ['status:done']
-            });
-            console.log(`Added status:done label to issue: ${issueNumber}`);
+            if (github?.issues?.removeLabel && github?.issues?.addLabels) {
+              await github.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: 'status:review'
+              }).catch(() => console.log('status:review label not found on issue'));
+              await github.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['status:done']
+              });
+              console.log(`Added status:done label to issue: ${issueNumber}`);
+            } else {
+              console.log('Error: github.issues.removeLabel or github.issues.addLabels is not available');
+            }
           }

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -1,0 +1,98 @@
+name: Update Status Labels
+
+on:
+  pull_request:
+    types:
+      - opened
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  update-labels:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set PR status to review
+      if: ${{ github.event.action == 'opened' }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const prNumber = context.payload.pull_request.number;
+          await github.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            labels: ['status:review']
+          });
+
+          const linkedIssues = context.payload.pull_request.body.match(/(?:Fixes|Closes) #\d+/g) || [];
+          for (const issueRef of linkedIssues) {
+            const issueNumber = parseInt(issueRef.split('#')[1]);
+            await github.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              name: 'status:idea'
+            }).catch(() => {});
+            await github.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              name: 'status:todo'
+            }).catch(() => {});
+            await github.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              name: 'status:doing'
+            }).catch(() => {});
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['status:review']
+            });
+          }
+
+    - name: Set PR and linked issues to done
+      if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const prNumber = context.payload.pull_request.number;
+          await github.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            name: 'status:review'
+          }).catch(() => {});
+          await github.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            labels: ['status:done']
+          });
+
+          const linkedIssues = context.payload.pull_request.body.match(/(?:Fixes|Closes) #\d+/g) || [];
+          for (const issueRef of linkedIssues) {
+            const issueNumber = parseInt(issueRef.split('#')[1]);
+            await github.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              name: 'status:review'
+            }).catch(() => {});
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['status:done']
+            });
+          }

--- a/.github/workflows/status-label.yml
+++ b/.github/workflows/status-label.yml
@@ -35,8 +35,11 @@ jobs:
           }
           console.log(`PR Number: ${prNumber}`);
 
-          // Remove all labels starting with 'status:' from the PR, except 'status:review'
+          // Print current labels on the PR
           const prLabels = context.payload.pull_request.labels || [];
+          console.log('Current PR Labels:', prLabels.map(label => label.name));
+
+          // Remove all labels starting with 'status:' from the PR, except 'status:review'
           let alreadyInReview = false;
           for (const label of prLabels) {
             if (label.name === 'status:review') {
@@ -68,15 +71,20 @@ jobs:
             const issueNumber = parseInt(issueRef.split('#')[1]);
             console.log(`Processing linked issue: ${issueNumber}`);
 
-            // Remove all labels starting with 'status:' from the linked issue
+            // Print current labels on the linked issue
             const issueLabels = (await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber
             })).data;
+            console.log(`Current Labels on Issue #${issueNumber}:`, issueLabels.map(label => label.name));
 
+            // Check if 'status:review' is already present
+            let alreadyInReview = false;
             for (const label of issueLabels) {
-              if (label.name.startsWith('status:')) {
+              if (label.name === 'status:review') {
+                alreadyInReview = true;
+              } else if (label.name.startsWith('status:')) {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -86,14 +94,18 @@ jobs:
               }
             }
 
-            // Add 'status:review' label to the linked issue
-            await github.rest.issues.addLabels({
+            // Add 'status:review' label to the linked issue if not already present
+            if (!alreadyInReview) {
+              await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               labels: ['status:review']
-            });
-            console.log(`Added status:review label to issue: ${issueNumber}`);
+              });
+              console.log(`Added status:review label to issue: ${issueNumber}`);
+            } else {
+              console.log(`status:review label already present on issue: ${issueNumber}`);
+            }
           }
 
     - name: Set PR and linked issues to done


### PR DESCRIPTION
# Feat: Automate Status Labeling for PRs and Issues

Closes #124

<div align="center">
<img src="https://github.com/user-attachments/assets/89b2d7ab-fd08-4e29-920d-742a843d917b">
</div>

This PR introduces a new GitHub Actions workflow (`.github/workflows/status-label.yml`) to automate the management of status labels (`status:review`, `status:done`) on Pull Requests and their linked Issues.

**Motivation:**

Manually updating status labels across PRs and related Issues is tedious and prone to inconsistency. This automation ensures that labels accurately reflect the development stage based on the PR lifecycle, providing a clearer view of progress for everyone involved.

**Functionality:**

The workflow triggers on `pull_request` events (`opened`, `closed` when merged):

1.  **On PR Open:**
    * Adds the `status:review` label to the PR itself.
    * Finds Issues linked via keywords (e.g., `Closes #123`) or the GitHub UI.
    * For each linked Issue: removes any existing `status:idea`, `status:todo`, or `status:doing` labels and adds `status:review`.
2.  **On PR Merge:**
    * Removes the `status:review` label from the PR and adds `status:done`.
    * Finds linked Issues (as above).
    * For each linked Issue: removes the `status:review` label and adds `status:done`.

This automation streamlines status tracking and maintains consistency between PRs and the issues they resolve.

## 🔧 Changelog

* **Feat**
    * Added GitHub Actions workflow to automatically apply `status:review` and `status:done` labels to PRs and linked issues based on PR open/merge events.

